### PR TITLE
Hibernate3Module.Feature.SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECT...

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/hibernate3/Hibernate3Module.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/hibernate3/Hibernate3Module.java
@@ -27,7 +27,15 @@ public class Hibernate3Module extends Module
          * 
          * @since 0.7.0
          */
-        USE_TRANSIENT_ANNOTATION(true)
+        USE_TRANSIENT_ANNOTATION(true),
+
+		/**
+		 * If FORCE_LAZY_LOADING is false lazy-loaded object should be serialized as map IdentifierName=>IdentifierValue
+		 * istead of null (true); or serialized as nulls (false)
+		 * <p>
+		 * Defaul value is false
+		 */
+		SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS(false)
         ;
 
         final boolean _defaultState;

--- a/src/main/java/com/fasterxml/jackson/datatype/hibernate3/HibernateProxySerializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/hibernate3/HibernateProxySerializer.java
@@ -1,6 +1,8 @@
 package com.fasterxml.jackson.datatype.hibernate3;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.proxy.LazyInitializer;
@@ -29,6 +31,8 @@ public class HibernateProxySerializer
     protected final BeanProperty _property;
 
     protected final boolean _forceLazyLoading;
+	
+    protected final boolean _serializeIdentifierForLazyNotLoadedObjects;
 
     /**
      * For efficient serializer lookup, let's use this; most
@@ -47,7 +51,16 @@ public class HibernateProxySerializer
         _forceLazyLoading = forceLazyLoading;
         _dynamicSerializers = PropertySerializerMap.emptyMap();
         _property = null;
+        _serializeIdentifierForLazyNotLoadedObjects = false;
     }
+	
+    public HibernateProxySerializer(boolean forceLazyLoading, boolean serializeIdentifierForLazyNotLoadedObjects)
+    {
+        _forceLazyLoading = forceLazyLoading;
+        _dynamicSerializers = PropertySerializerMap.emptyMap();
+        _property = null;
+        _serializeIdentifierForLazyNotLoadedObjects = serializeIdentifierForLazyNotLoadedObjects;
+	}
 
     /*
     /**********************************************************************
@@ -62,8 +75,18 @@ public class HibernateProxySerializer
         Object proxiedValue = findProxied(value);
         // TODO: figure out how to suppress nulls, if necessary? (too late for that here)
         if (proxiedValue == null) {
-            provider.defaultSerializeNull(jgen);
-            return;
+            if(_serializeIdentifierForLazyNotLoadedObjects && value!=null) {
+                /* Instead of serialize hibernate proxy as null we serialize
+                 * it as map IdentifierName=>IdentifierValue
+                 */
+                final String idName = value.getHibernateLazyInitializer().getSession().getFactory().getIdentifierPropertyName(value.getHibernateLazyInitializer().getEntityName());
+                final Object idValue = value.getHibernateLazyInitializer().getIdentifier();
+                if(idName!=null && idValue!=null)
+                    proxiedValue = new HashMap<String, Object>() {{ put(idName, idValue); }};
+            } else {
+                provider.defaultSerializeNull(jgen);
+                return;
+            }
         }
         findSerializer(provider, proxiedValue).serialize(proxiedValue, jgen, provider);
     }
@@ -74,8 +97,15 @@ public class HibernateProxySerializer
     {
         Object proxiedValue = findProxied(value);
         if (proxiedValue == null) {
-            provider.defaultSerializeNull(jgen);
-            return;
+            if(_serializeIdentifierForLazyNotLoadedObjects && value!=null) {
+                final String idName = value.getHibernateLazyInitializer().getSession().getFactory().getIdentifierPropertyName(value.getHibernateLazyInitializer().getEntityName());
+                final Object idValue = value.getHibernateLazyInitializer().getIdentifier();
+                if(idName!=null && idValue!=null)
+                    proxiedValue = new HashMap<String, Object>() {{ put(idName, idValue); }};
+            } else {
+                provider.defaultSerializeNull(jgen);
+                return;
+            }
         }
         /* This isn't exactly right, since type serializer really refers to proxy
          * object, not value. And we really don't either know static type (necessary

--- a/src/main/java/com/fasterxml/jackson/datatype/hibernate3/HibernateSerializers.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/hibernate3/HibernateSerializers.java
@@ -36,7 +36,7 @@ public class HibernateSerializers extends Serializers.Base
         }
         
         if (HibernateProxy.class.isAssignableFrom(raw)) {
-            return new HibernateProxySerializer(isEnabled(Feature.FORCE_LAZY_LOADING));
+            return new HibernateProxySerializer(isEnabled(Feature.FORCE_LAZY_LOADING), isEnabled(Feature.SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS));
         }
         return null;
     }


### PR DESCRIPTION
...S

When you activate this option, the proxy object serializes it's ID
instead of null
