### PR TITLE
Fix for issue #39

### DIFF
--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/Hibernate4Module.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/Hibernate4Module.java
@@ -3,11 +3,12 @@ package com.fasterxml.jackson.datatype.hibernate4;
 import com.fasterxml.jackson.core.Version;
 
 import com.fasterxml.jackson.databind.*;
+import org.hibernate.engine.spi.Mapping;
 
 public class Hibernate4Module extends Module
 {
     /**
-     * Enumeration that defines all togglable features this module
+     * Enumeration that defines all toggleable features this module
      */
     public enum Feature {
         /**
@@ -29,9 +30,9 @@ public class Hibernate4Module extends Module
         
 	    /**
 	     * If FORCE_LAZY_LOADING is false lazy-loaded object should be serialized as map IdentifierName=>IdentifierValue
-	     * istead of null (true); or serialized as nulls (false)
+	     * instead of null (true); or serialized as nulls (false)
 	     * <p>
-	     * Defaul value is false
+	     * Default value is false
 	     */
         SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS(false)        
         ;
@@ -71,14 +72,25 @@ public class Hibernate4Module extends Module
      * are enabled.
      */
     protected int _moduleFeatures = DEFAULT_FEATURES;
-    
+
+    /**
+     * Hibernate mapping.
+     */
+    protected final Mapping _mapping;
+
     /*
     /**********************************************************************
     /* Life-cycle
     /**********************************************************************
      */
-    
-    public Hibernate4Module() { }
+
+    public Hibernate4Module() {
+        this(null);
+    }
+
+    public Hibernate4Module(Mapping mapping) {
+        _mapping = mapping;
+    }
 
     @Override public String getModuleName() { return "jackson-datatype-hibernate"; }
     @Override public Version version() { return ModuleVersion.instance.version(); }
@@ -95,7 +107,7 @@ public class Hibernate4Module extends Module
             context.appendAnnotationIntrospector(ai);
         }
         boolean forceLoading = isEnabled(Feature.FORCE_LAZY_LOADING);
-        context.addSerializers(new HibernateSerializers(forceLoading, isEnabled(Feature.SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS)));
+        context.addSerializers(new HibernateSerializers(forceLoading, isEnabled(Feature.SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS), _mapping));
         context.addBeanSerializerModifier(new HibernateSerializerModifier(forceLoading));
     }
 

--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/HibernateSerializers.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/HibernateSerializers.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.datatype.hibernate4;
 
+import org.hibernate.engine.spi.Mapping;
 import org.hibernate.proxy.HibernateProxy;
 
 import com.fasterxml.jackson.databind.*;
@@ -9,17 +10,23 @@ public class HibernateSerializers extends Serializers.Base
 {
     protected final boolean _forceLoading;
     protected final boolean _serializeIdentifiers;
-    
+    protected final Mapping _mapping;
+
     public HibernateSerializers(boolean forceLoading)
     {
-        _forceLoading = forceLoading;
-        _serializeIdentifiers = false;
-    }    
-    
+        this(forceLoading, false, null);
+    }
+
     public HibernateSerializers(boolean forceLoading, boolean serializeIdentifiers)
+    {
+        this(forceLoading, serializeIdentifiers, null);
+    }
+
+    public HibernateSerializers(boolean forceLoading, boolean serializeIdentifiers, Mapping mapping)
     {
         _forceLoading = forceLoading;
         _serializeIdentifiers = serializeIdentifiers;
+        _mapping = mapping;
     }
 
     @Override
@@ -28,7 +35,7 @@ public class HibernateSerializers extends Serializers.Base
     {
         Class<?> raw = type.getRawClass();
         if (HibernateProxy.class.isAssignableFrom(raw)) {
-            return new HibernateProxySerializer(_forceLoading, _serializeIdentifiers);
+            return new HibernateProxySerializer(_forceLoading, _serializeIdentifiers, _mapping);
         }
         return null;
     }


### PR DESCRIPTION
Added a new constructor to the `Hibernate4Module` where you can pass your Hibernate `Mapping` object. Usage example:

```
    // Create Hibernate configuration & get build mapping.
    final Configuration configuration = new Configuration().configure("hibernate.cfg.xml");
    final Mapping mapping = configuration.buildMapping();

    // Create Hibernate4Module with Hibernate mapping.
    final Hibernate4Module hibernate4Module = new Hibernate4Module(mapping);

    // Register Hibernate4Module with ObjectMapper.
    final ObjectMapper mapper = new ObjectMapper(new JsonFactory());
    mapper.registerModule(hibernate4Module);
```
