### PR TITLE
Entity class instance as identifier instead of HashMap

### DIFF
--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/Hibernate4Module.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/Hibernate4Module.java
@@ -1,5 +1,7 @@
 package com.fasterxml.jackson.datatype.hibernate4;
 
+import javax.persistence.Id;
+
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.*;
@@ -56,11 +58,13 @@ public class Hibernate4Module extends Module
         REQUIRE_EXPLICIT_LAZY_LOADING_MARKER(false),
         
         /**
-         * This feature takes effect only when {@link #SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS} is enabled. 
-         * Defines if the serializer should try to create an instance of the actual persistent class 
-         * and set the idValue to the idProperty of the actual class, instead of using a Map. 
-         * This is especially useful, when dealing with inheritance and {@link JsonTypeInfo} so that type information
+         * Defines if the serializer should create an instance of the actual entity class 
+         * and set the id value to the id property (@link {@link Id}) of the actual class, instead of using a Map. 
+         * Useful, when dealing with inheritance and {@link JsonTypeInfo} so that type information
          * is not lost for not initialized lazy objects. 
+         * <p/>
+         * This feature is taken into account only when {@link #SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS} is enabled. 
+         * Default value is false.
          * 
          * @since 2.4
          */

--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/Hibernate4Module.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/Hibernate4Module.java
@@ -1,8 +1,9 @@
 package com.fasterxml.jackson.datatype.hibernate4;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.Version;
-
 import com.fasterxml.jackson.databind.*;
+
 import org.hibernate.engine.spi.Mapping;
 
 public class Hibernate4Module extends Module
@@ -30,6 +31,7 @@ public class Hibernate4Module extends Module
         
 	    /**
 	     * If FORCE_LAZY_LOADING is false lazy-loaded object should be serialized as map IdentifierName=>IdentifierValue
+	     * or as entity class with only id value set (based on SERIALIZE_IDENTIFIER_USE_PERSISTENT_CLASS setting)
 	     * instead of null (true); or serialized as nulls (false)
 	     * <p>
 	     * Default value is false.
@@ -52,6 +54,17 @@ public class Hibernate4Module extends Module
          * @since 2.4
          */
         REQUIRE_EXPLICIT_LAZY_LOADING_MARKER(false),
+        
+        /**
+         * This feature takes effect only when {@link #SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS} is enabled. 
+         * Defines if the serializer should try to create an instance of the actual persistent class 
+         * and set the idValue to the idProperty of the actual class, instead of using a Map. 
+         * This is especially useful, when dealing with inheritance and {@link JsonTypeInfo} so that type information
+         * is not lost for not initialized lazy objects. 
+         * 
+         * @since 2.4
+         */
+        SERIALIZE_IDENTIFIER_USE_PERSISTENT_CLASS(false)
         ;
 
         final boolean _defaultState;

--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/HibernateProxySerializer.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/HibernateProxySerializer.java
@@ -37,7 +37,7 @@ public class HibernateProxySerializer
     protected final boolean _serializeIdentifier;
     protected final boolean _usePersistentClassForIdentifier;
     protected final Mapping _mapping;
-    protected final IdentifierTypeFactory _identifierTyperFactory;
+    protected final IdentifierTypeFactory _identifierTypeFactory;
 
     /**
      * For efficient serializer lookup, let's use this; most
@@ -73,9 +73,9 @@ public class HibernateProxySerializer
         _dynamicSerializers = PropertySerializerMap.emptyMap();
         _property = null;
         if(_usePersistentClassForIdentifier){
-            _identifierTyperFactory = new IdentifierTypeFactory();
+            _identifierTypeFactory = new IdentifierTypeFactory();
         }else {
-            _identifierTyperFactory = null;
+            _identifierTypeFactory = null;
         }
     }
 
@@ -174,7 +174,7 @@ public class HibernateProxySerializer
                 final Object idValue = init.getIdentifier();
                 if (_usePersistentClassForIdentifier) {
                     Class<?> persistentClass = init.getPersistentClass();
-                    Object identifierClass = _identifierTyperFactory.createInstanceWithIdValue(persistentClass, idName, idValue);
+                    Object identifierClass = _identifierTypeFactory.createInstanceWithIdValue(persistentClass, idName, idValue);
                     return identifierClass;
                 } else {
                     HashMap<String, Object> map = new HashMap<String, Object>();

--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/HibernateSerializers.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/HibernateSerializers.java
@@ -11,6 +11,7 @@ public class HibernateSerializers extends Serializers.Base
 {
     protected final boolean _forceLoading;
     protected final boolean _serializeIdentifiers;
+    protected final boolean _usePersistentClassForIdentifier;
     protected final Mapping _mapping;
 
     public HibernateSerializers(int features) {
@@ -21,6 +22,7 @@ public class HibernateSerializers extends Serializers.Base
     {
         _forceLoading = Feature.FORCE_LAZY_LOADING.enabledIn(features);
         _serializeIdentifiers = Feature.SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS.enabledIn(features);
+        _usePersistentClassForIdentifier = Feature.SERIALIZE_IDENTIFIER_USE_PERSISTENT_CLASS.enabledIn(features);
         _mapping = mapping;
     }
 
@@ -30,7 +32,7 @@ public class HibernateSerializers extends Serializers.Base
     {
         Class<?> raw = type.getRawClass();
         if (HibernateProxy.class.isAssignableFrom(raw)) {
-            return new HibernateProxySerializer(_forceLoading, _serializeIdentifiers, _mapping);
+            return new HibernateProxySerializer(_forceLoading, _serializeIdentifiers, _usePersistentClassForIdentifier, _mapping);
         }
         return null;
     }

--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/IdentifierTypeFactory.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/IdentifierTypeFactory.java
@@ -1,0 +1,113 @@
+package com.fasterxml.jackson.datatype.hibernate4;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.persistence.Id;
+
+import com.fasterxml.jackson.datatype.hibernate4.Hibernate4Module.Feature;
+
+/**
+ * Factory to create instances of persistentClass with {@link Id} property set to given value. <p/>
+ * Used by {@link HibernateProxySerializer} in case {@link Feature#SERIALIZE_IDENTIFIER_USE_PERSISTENT_CLASS} is enabled.
+ * @see #createInstanceWithIdValue(Class, String, Object)
+ * @author arthupka
+ * @since 2.4
+ */
+public class IdentifierTypeFactory {
+    static final ConcurrentHashMap<CacheKey, Field> _idFieldCache = new ConcurrentHashMap<CacheKey, Field>();
+
+    Object createInstanceWithIdValue(Class<?> persistentClass, final String idName, final Object idValue) {
+        try {
+            Constructor<?> defaultConstructor = persistentClass.getDeclaredConstructor();
+            defaultConstructor.setAccessible(true);
+            Object instance = defaultConstructor.newInstance();
+            Field idField = getIdField(persistentClass, idName, instance);
+            if(!idField.isAccessible()){
+                idField.setAccessible(true);
+            }
+            idField.set(instance, idValue);
+            return instance;
+        } catch (Exception e) {
+            throw new IllegalStateException("Error creating identifier class [" + persistentClass.getSimpleName() + "] and "
+                    + "setting idValue with [" + idName + "=" + idValue + "]. Default constructor present and field available?",
+                    e);
+        }
+    }
+
+    private Field getIdField(Class<?> persistentClass, String idName, Object instance) throws NoSuchMethodException {
+        CacheKey cacheKey = new CacheKey(persistentClass.getCanonicalName(), idName);
+        Field field = _idFieldCache.get(cacheKey);
+        if (field != null) {
+            return field;
+        }
+        else {
+            synchronized (_idFieldCache) {
+                field = _idFieldCache.get(cacheKey);
+                if (field == null) {
+                    field = findField(persistentClass, idName, instance);
+                    _idFieldCache.put(cacheKey, field);
+                }
+                return field;
+            }
+        }
+    }
+
+    private Field findField(Class<?> persistentClass, String idName, Object instance) throws NoSuchMethodException {
+        if (persistentClass == null) {
+            return null;
+        }
+        Field field;
+        try {
+            field = persistentClass.getDeclaredField(idName);
+        } catch (NoSuchFieldException e) {
+            field = findField(persistentClass.getSuperclass(), idName, instance);
+        }
+        return field;
+    }
+
+    private static class CacheKey {
+        private final String clazz;
+        private final String idName;
+
+        public CacheKey(String clazz, String idName) {
+            super();
+            this.clazz = clazz;
+            this.idName = idName;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((clazz == null) ? 0 : clazz.hashCode());
+            result = prime * result + ((idName == null) ? 0 : idName.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            CacheKey other = (CacheKey) obj;
+            if (clazz == null) {
+                if (other.clazz != null)
+                    return false;
+            } else if (!clazz.equals(other.clazz))
+                return false;
+            if (idName == null) {
+                if (other.idName != null)
+                    return false;
+            } else if (!idName.equals(other.idName))
+                return false;
+            return true;
+        }
+
+    }
+
+}

--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/IdentifierTypeFactory.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/IdentifierTypeFactory.java
@@ -24,6 +24,9 @@ public class IdentifierTypeFactory {
             defaultConstructor.setAccessible(true);
             Object instance = defaultConstructor.newInstance();
             Field idField = getIdField(persistentClass, idName, instance);
+            if(idField == null){
+                throw new NoSuchFieldError("Field "+idName+" not found in class "+persistentClass.getName());
+            }
             if(!idField.isAccessible()){
                 idField.setAccessible(true);
             }

--- a/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/HibernateProxySerializerTest.java
+++ b/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/HibernateProxySerializerTest.java
@@ -1,0 +1,29 @@
+package com.fasterxml.jackson.datatype.hibernate4;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HibernateProxySerializerTest {
+
+    @Test
+    public void testCreateTargetIdentifierClassAndSetIdValue() throws Exception {
+        HibernateProxySerializer s = new HibernateProxySerializer(false);
+        Object object = s.createTargetIdentifierClassAndSetIdValue(TestClassA.class, "id", 1L);
+        Assert.assertEquals(TestClassA.class, object.getClass());
+        Assert.assertEquals(((SuperClass) object).id.longValue(), 1L);
+        @SuppressWarnings("rawtypes")
+        Map cache = HibernateProxySerializer._idFieldCache;
+        Assert.assertTrue(cache.size() == 1);
+    }
+
+    static class SuperClass {
+        private Long id;
+    }
+
+    static class TestClassA extends SuperClass {
+        String name;
+    }
+
+}

--- a/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/IdentifierTypeFactoryTest.java
+++ b/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/IdentifierTypeFactoryTest.java
@@ -5,16 +5,16 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class HibernateProxySerializerTest {
+public class IdentifierTypeFactoryTest {
 
     @Test
-    public void testCreateTargetIdentifierClassAndSetIdValue() throws Exception {
-        HibernateProxySerializer s = new HibernateProxySerializer(false);
-        Object object = s.createTargetIdentifierClassAndSetIdValue(TestClassA.class, "id", 1L);
+    public void testCreateInstanceWithIdValue() throws Exception {
+        IdentifierTypeFactory s = new IdentifierTypeFactory();
+        Object object = s.createInstanceWithIdValue(TestClassA.class, "id", 1L);
         Assert.assertEquals(TestClassA.class, object.getClass());
         Assert.assertEquals(((SuperClass) object).id.longValue(), 1L);
         @SuppressWarnings("rawtypes")
-        Map cache = HibernateProxySerializer._idFieldCache;
+        Map cache = IdentifierTypeFactory._idFieldCache;
         Assert.assertTrue(cache.size() == 1);
     }
 

--- a/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/TestVersions.java
+++ b/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/TestVersions.java
@@ -2,7 +2,6 @@ package com.fasterxml.jackson.datatype.hibernate4;
 
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.core.Versioned;
-import com.fasterxml.jackson.datatype.hibernate4.Hibernate4Module;
 
 public class TestVersions extends BaseTest
 {


### PR DESCRIPTION
I've implemented a Feature 'SERIALIZE_IDENTIFIER_USE_PERSISTENT_CLASS' that allows to configure if HibernateProxySerializer should instantiate the actual Entity class and set the Id value in case SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS is set to true. 
This is especially useful in cases where Type inheritance is used with Jackson (@JsonTypeInfo). 
This feature defaults to false and can optionally be enabled in case SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS is enabled.

Without this feature the type information is lost for the client i.e. HashMap is returned as type info.