### PR TITLE
Add Feature.ALWAYS_SERIALIZE_LAZY_LOADED_OBJECTS_AS_IDENTIFIER

### DIFF
--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/Hibernate4Module.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/Hibernate4Module.java
@@ -39,6 +39,14 @@ public class Hibernate4Module extends Module
         SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS(false),
 
         /**
+         * Serialize all Hibernate lazy loaded object properties as map IdentifierName=>IdentifierValue,
+         * even if the object has already been loaded.
+         * <p>
+         * Default value is false.
+         */
+        ALWAYS_SERIALIZE_LAZY_LOADED_OBJECTS_AS_IDENTIFIER(false),
+
+        /**
          * This feature determines how {@link org.hibernate.collection.spi.PersistentCollection}s properties
          * for which no annotation is found are handled with respect to
          * lazy-loading: if true, lazy-loading is only assumed if annotation

--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/HibernateProxySerializer.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/HibernateProxySerializer.java
@@ -33,7 +33,8 @@ public class HibernateProxySerializer
     protected final BeanProperty _property;
 
     protected final boolean _forceLazyLoading;
-    protected final boolean _serializeIdentifier;
+    protected final boolean _serializeIdentifierIfNotInitialized;
+    protected final boolean _alwaysSerializeIdentifier;
     protected final Mapping _mapping;
 
     /**
@@ -50,16 +51,23 @@ public class HibernateProxySerializer
 
     public HibernateProxySerializer(boolean forceLazyLoading)
     {
-        this(forceLazyLoading, false, null);
+        this(forceLazyLoading, false, false, null);
     }
 
-    public HibernateProxySerializer(boolean forceLazyLoading, boolean serializeIdentifier) {
-        this(forceLazyLoading, serializeIdentifier, null);
+    public HibernateProxySerializer(boolean forceLazyLoading, boolean serializeIdentifierIfNotInitialized) {
+        this(forceLazyLoading, serializeIdentifierIfNotInitialized, false, null);
     }
 
-    public HibernateProxySerializer(boolean forceLazyLoading, boolean serializeIdentifier, Mapping mapping) {
+    public HibernateProxySerializer(boolean forceLazyLoading, boolean serializeIdentifierIfNotInitialized,
+            boolean serializeIdentifierOnly) {
+        this(forceLazyLoading, serializeIdentifierIfNotInitialized, serializeIdentifierOnly, null);
+    }
+
+    public HibernateProxySerializer(boolean forceLazyLoading, boolean serializeIdentifierIfNotInitialized,
+            boolean alwaysSerializeIdentifier, Mapping mapping) {
         _forceLazyLoading = forceLazyLoading;
-        _serializeIdentifier = serializeIdentifier;
+        _serializeIdentifierIfNotInitialized = serializeIdentifierIfNotInitialized;
+        _alwaysSerializeIdentifier = alwaysSerializeIdentifier;
         _mapping = mapping;
         _dynamicSerializers = PropertySerializerMap.emptyMap();
         _property = null;
@@ -144,8 +152,8 @@ public class HibernateProxySerializer
     protected Object findProxied(HibernateProxy proxy)
     {
         LazyInitializer init = proxy.getHibernateLazyInitializer();
-        if (!_forceLazyLoading && init.isUninitialized()) {
-            if (_serializeIdentifier) {
+        if (_alwaysSerializeIdentifier || (!_forceLazyLoading && init.isUninitialized())) {
+            if (_alwaysSerializeIdentifier || _serializeIdentifierIfNotInitialized) {
                 final String idName;
                 if (_mapping != null) {
                     idName = _mapping.getIdentifierPropertyName(init.getEntityName());

--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/HibernateSerializers.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/HibernateSerializers.java
@@ -12,7 +12,8 @@ import org.hibernate.proxy.HibernateProxy;
 public class HibernateSerializers extends Serializers.Base
 {
     protected final boolean _forceLoading;
-    protected final boolean _serializeIdentifiers;
+    protected final boolean _serializeIdentifierIfNotInitialized;
+    protected final boolean _alwaysSerializeIdentifiers;
     protected final Mapping _mapping;
 
     public HibernateSerializers(int features) {
@@ -22,7 +23,8 @@ public class HibernateSerializers extends Serializers.Base
     public HibernateSerializers(Mapping mapping, int features)
     {
         _forceLoading = Feature.FORCE_LAZY_LOADING.enabledIn(features);
-        _serializeIdentifiers = Feature.SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS.enabledIn(features);
+        _serializeIdentifierIfNotInitialized = Feature.SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS.enabledIn(features);
+        _alwaysSerializeIdentifiers = Feature.ALWAYS_SERIALIZE_LAZY_LOADED_OBJECTS_AS_IDENTIFIER.enabledIn(features);
         _mapping = mapping;
     }
 
@@ -32,7 +34,8 @@ public class HibernateSerializers extends Serializers.Base
     {
         Class<?> raw = type.getRawClass();
         if (HibernateProxy.class.isAssignableFrom(raw)) {
-            return new HibernateProxySerializer(_forceLoading, _serializeIdentifiers, _mapping);
+            return new HibernateProxySerializer(_forceLoading, _serializeIdentifierIfNotInitialized,
+                    _alwaysSerializeIdentifiers, _mapping);
         }
         return null;
     }

--- a/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/AlwaysSerializeIdentifierTest.java
+++ b/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/AlwaysSerializeIdentifierTest.java
@@ -1,0 +1,71 @@
+package com.fasterxml.jackson.datatype.hibernate4;
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+import org.hibernate.Hibernate;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.hibernate4.Hibernate4Module.Feature;
+import com.fasterxml.jackson.datatype.hibernate4.data.Employee;
+
+/**
+ * Test Hibernate4Module.Feature.SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS
+ */
+public class AlwaysSerializeIdentifierTest extends BaseTest
+{
+    @Test
+    public void testAlwaysSerializeAsIdentifierFeature() throws Exception
+    {
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory("persistenceUnit");
+
+        try {
+            EntityManager em = emf.createEntityManager();
+           
+            Employee employee = em.find(Employee.class, 1370);
+            // "office" is marked as lazily loaded
+            assertFalse(Hibernate.isInitialized(employee.getOffice()));
+
+            ObjectMapper mapper = mapperWithModule();            
+            String json = mapper.writeValueAsString(employee);
+            assertNotNull(json);
+            Map<?,?> stuff = mapper.readValue(json, Map.class);
+            // "office" should be serialized as null
+            assertTrue(stuff.containsKey("office"));
+            assertNull(stuff.get("office"));
+
+            //"office" should be serialized as an identifier when uninitialized
+            mapper = mapperWithModule(Feature.ALWAYS_SERIALIZE_LAZY_LOADED_OBJECTS_AS_IDENTIFIER, true);
+            verifySerializedAsIdentifier(employee, mapper);
+
+            //"office" should be serialized as an identifier even when already initialized
+            Hibernate.initialize(employee.getOffice());
+            assertTrue(Hibernate.isInitialized(employee.getOffice()));
+            verifySerializedAsIdentifier(employee, mapper);
+        } finally {
+            emf.close();
+        }
+    }
+
+    private void verifySerializedAsIdentifier(Employee employee, ObjectMapper mapper) throws IOException {
+        String json = mapper.writeValueAsString(employee);
+        assertNotNull(json);
+        Map<?,?> stuff = mapper.readValue(json, Map.class);
+        // "office" should be serialized as identifier
+        assertTrue(stuff.containsKey("office"));
+
+        Object officeObj = stuff.get("office");
+        assertTrue(officeObj instanceof Map);
+        Map<?,?> office = (Map<?,?>) officeObj;
+
+        //make sure there's only one property on office
+        assertEquals(1, office.size());
+        assertTrue(office.containsKey("officeCode"));
+        assertEquals("4", office.get("officeCode"));          
+    }
+}

--- a/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/BaseTest.java
+++ b/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/BaseTest.java
@@ -4,20 +4,33 @@ import java.util.Arrays;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.hibernate4.Hibernate4Module;
+import com.fasterxml.jackson.datatype.hibernate4.Hibernate4Module.Feature;
 
 public abstract class BaseTest extends junit.framework.TestCase
 {
     protected BaseTest() { }
 
-    protected ObjectMapper mapperWithModule(boolean forceLazyLoading)
+    protected ObjectMapper mapperWithModule()
     {
-        return new ObjectMapper().registerModule(hibernateModule(forceLazyLoading));
+        return new ObjectMapper().registerModule(hibernateModule());
     }
 
-    protected Hibernate4Module hibernateModule(boolean forceLazyLoading)
+    protected ObjectMapper mapperWithModule(Feature f, boolean state)
+    {
+        return new ObjectMapper().registerModule(hibernateModule(f, state));
+    }
+
+    protected Hibernate4Module hibernateModule()
+    {
+        return hibernateModule(null, false);
+    }
+
+    protected Hibernate4Module hibernateModule(Feature f, boolean state)
     {
         Hibernate4Module mod = new Hibernate4Module();
-        mod.configure(Hibernate4Module.Feature.FORCE_LAZY_LOADING, forceLazyLoading);
+        if (f != null) {
+            mod.configure(f, state);
+        }
         return mod;
     }
     

--- a/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/ForceLazyLoadingTest.java
+++ b/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/ForceLazyLoadingTest.java
@@ -1,14 +1,17 @@
 package com.fasterxml.jackson.datatype.hibernate4;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.hibernate4.Hibernate4Module.Feature;
 import com.fasterxml.jackson.datatype.hibernate4.data.Customer;
 import com.fasterxml.jackson.datatype.hibernate4.data.Payment;
+
 import org.hibernate.Hibernate;
 import org.junit.Test;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
+
 import java.util.Map;
 import java.util.Set;
 
@@ -22,10 +25,9 @@ public class ForceLazyLoadingTest extends BaseTest
 
         try {
             EntityManager em = emf.createEntityManager();
-            
-            // false -> no forcing of lazy loading
-            ObjectMapper mapper = mapperWithModule(true);
-            
+
+            ObjectMapper mapper = mapperWithModule(Feature.FORCE_LAZY_LOADING, true);
+
             Customer customer = em.find(Customer.class, 103);
             assertFalse(Hibernate.isInitialized(customer.getPayments()));
             String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(customer);

--- a/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/HibernateTest.java
+++ b/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/HibernateTest.java
@@ -43,7 +43,7 @@ public class HibernateTest extends BaseTest
     @Test
     public void testGetCustomerJson() throws Exception {
         EntityManager em = emf.createEntityManager();
-        ObjectMapper mapper = mapperWithModule(false);
+        ObjectMapper mapper = mapperWithModule();
         String json = mapper.writeValueAsString(em.find(Customer.class, 103));
         
         // TODO: verify
@@ -62,7 +62,7 @@ public class HibernateTest extends BaseTest
         
         Query query = em.createQuery("select c from Customer c");
         // false -> no forcing of lazy loading
-        ObjectMapper mapper = mapperWithModule(false);
+        ObjectMapper mapper = mapperWithModule();
         String json = mapper.writeValueAsString(query.getResultList());
 
         // TODO: verify
@@ -89,7 +89,7 @@ public class HibernateTest extends BaseTest
         Assert.assertTrue(salesEmployee.getCustomers().size()>0);
         
         // false -> no forcing of lazy loading
-        ObjectMapper mapper = mapperWithModule(false);
+        ObjectMapper mapper = mapperWithModule();
         String json = mapper.writeValueAsString(salesEmployee);
 
         // Ok; let's try reading back

--- a/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/LazyLoadingTest.java
+++ b/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/LazyLoadingTest.java
@@ -25,7 +25,7 @@ public class LazyLoadingTest extends BaseTest
             EntityManager em = emf.createEntityManager();
             
             // false -> no forcing of lazy loading
-            ObjectMapper mapper = mapperWithModule(false);
+            ObjectMapper mapper = mapperWithModule();
             
             Customer customer = em.find(Customer.class, 103);
             assertFalse(Hibernate.isInitialized(customer.getPayments()));

--- a/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/TestMaps.java
+++ b/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/TestMaps.java
@@ -8,7 +8,7 @@ public class TestMaps extends BaseTest
 {
     public void testSimpleMap() throws Exception
     {
-        ObjectMapper mapper = mapperWithModule(false);
+        ObjectMapper mapper = mapperWithModule();
         Map<String,Integer> map = new HashMap<String,Integer>();
         map.put("a", Integer.valueOf(1));
         String json = mapper.writeValueAsString(map);

--- a/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/TransientTest.java
+++ b/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/TransientTest.java
@@ -27,13 +27,11 @@ public class TransientTest extends BaseTest
      public void testSimpleTransient() throws Exception
      {
           // First, with defaults, which allow use of Transient
-          ObjectMapper mapper = mapperWithModule(false);
+          ObjectMapper mapper = mapperWithModule();
           assertEquals(aposToQuotes("{'a':1}"), mapper.writeValueAsString(new WithTransient()));
 
           // and then with Transient disabled
-          Hibernate4Module mod = hibernateModule(false);
-          mod.disable(Hibernate4Module.Feature.USE_TRANSIENT_ANNOTATION);
-          mapper = new ObjectMapper().registerModule(mod);
+          mapper = mapperWithModule(Hibernate4Module.Feature.USE_TRANSIENT_ANNOTATION, false);
           
           assertEquals(aposToQuotes("{'a':1,'b':2}"), mapper.writeValueAsString(new WithTransient()));
      }

--- a/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/UninitializedIdentifierTest.java
+++ b/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/UninitializedIdentifierTest.java
@@ -1,0 +1,60 @@
+package com.fasterxml.jackson.datatype.hibernate4;
+
+import java.util.Map;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+import org.hibernate.Hibernate;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.hibernate4.Hibernate4Module.Feature;
+import com.fasterxml.jackson.datatype.hibernate4.data.Employee;
+
+/**
+ * Test Hibernate4Module.Feature.SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS
+ */
+public class UninitializedIdentifierTest extends BaseTest
+{
+    @Test
+    public void testUninitializedIdentifierFeature() throws Exception
+    {
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory("persistenceUnit");
+
+        try {
+            EntityManager em = emf.createEntityManager();
+           
+            Employee employee = em.find(Employee.class, 1370);
+            // "office" is marked as lazily loaded
+            assertFalse(Hibernate.isInitialized(employee.getOffice()));
+
+            ObjectMapper mapper = mapperWithModule();            
+            String json = mapper.writeValueAsString(employee);
+            assertNotNull(json);
+            Map<?,?> stuff = mapper.readValue(json, Map.class);
+            // "office" should be serialized as null
+            assertTrue(stuff.containsKey("office"));
+            assertNull(stuff.get("office"));
+
+            mapper = mapperWithModule(Feature.SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS, true);
+            json = mapper.writeValueAsString(employee);
+            assertNotNull(json);
+            stuff = mapper.readValue(json, Map.class);
+            // "office" should be serialized as identifier
+            assertTrue(stuff.containsKey("office"));
+
+            Object officeObj = stuff.get("office");
+            assertTrue(officeObj instanceof Map);
+            Map<?,?> office = (Map<?,?>) officeObj;
+
+            //make sure there's only one property on office
+            assertEquals(1, office.size());
+            assertTrue(office.containsKey("officeCode"));
+            assertEquals("4", office.get("officeCode"));            
+        } finally {
+            emf.close();
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds a Hibernate4Module feature to always serialize lazy loaded objects as bare identifiers, even if the object has already been initialized.

In my use case I need to have the serialization behave consistently whether or not objects have been loaded. Server code decides which full objects should be sent back in a result, and the client assembles the graph based on id fields.

I refactored BaseTest a bit to accomodate the growing number of features. The commit includes a test case for the new feature (AlwaysSerializeIdentifierTest). I also built a test for Feature.SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS, which previously didn't have one (UninitializedIdentifierTest).

I only implemented this for Hibernate4Module. Hibernate4Module seems to have several features not present in Hibernate3Module, and the last version of Hibernate 3 was released three years ago, so this seemed sensible to me.

If this request is merged I'll create another with a backport/cherry-pick to 2.4.

Also, I sent a completed [CLA agreement](https://github.com/FasterXML/jackson/blob/master/contributor-agreement.pdf) to info at fasterxml.com.
