### PR TITLE
Fix for #41 inspired by https://github.com/FasterXML/jackson-datatype-hibernate/pull/69

### DIFF
--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/ClonedBeanSerializer.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/ClonedBeanSerializer.java
@@ -1,0 +1,164 @@
+package com.fasterxml.jackson.datatype.hibernate4;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
+import com.fasterxml.jackson.databind.ser.BeanSerializerBuilder;
+import com.fasterxml.jackson.databind.ser.impl.BeanAsArraySerializer;
+import com.fasterxml.jackson.databind.ser.impl.ObjectIdWriter;
+import com.fasterxml.jackson.databind.ser.impl.UnwrappingBeanSerializer;
+import com.fasterxml.jackson.databind.ser.std.BeanSerializerBase;
+import com.fasterxml.jackson.databind.util.NameTransformer;
+
+import java.io.IOException;
+
+/**
+ * Clone of BeanSerializer, because we need to alter serialize method in HibernateProxySerializer
+ */
+public class ClonedBeanSerializer
+        extends BeanSerializerBase
+{
+    private static final long serialVersionUID = -4536893235025590367L;
+
+    /*
+    /**********************************************************
+    /* Life-cycle: constructors
+    /**********************************************************
+     */
+
+    /**
+     * @param builder Builder object that contains collected information
+     *   that may be needed for serializer
+     * @param properties Property writers used for actual serialization
+     */
+    public ClonedBeanSerializer(JavaType type, BeanSerializerBuilder builder,
+                                BeanPropertyWriter[] properties, BeanPropertyWriter[] filteredProperties)
+    {
+        super(type, builder, properties, filteredProperties);
+    }
+
+    /**
+     * Alternate copy constructor that can be used to construct
+     * standard {@link ClonedBeanSerializer} passing an instance of
+     * "compatible enough" source serializer.
+     */
+    protected ClonedBeanSerializer(BeanSerializerBase src) {
+        super(src);
+    }
+
+    protected ClonedBeanSerializer(BeanSerializerBase src,
+                                   ObjectIdWriter objectIdWriter) {
+        super(src, objectIdWriter);
+    }
+
+    protected ClonedBeanSerializer(BeanSerializerBase src,
+                                   ObjectIdWriter objectIdWriter, Object filterId) {
+        super(src, objectIdWriter, filterId);
+    }
+
+    protected ClonedBeanSerializer(BeanSerializerBase src, String[] toIgnore) {
+        super(src, toIgnore);
+    }
+
+    /*
+    /**********************************************************
+    /* Life-cycle: factory methods, fluent factories
+    /**********************************************************
+     */
+
+    /**
+     * Method for constructing dummy bean serializer; one that
+     * never outputs any properties
+     */
+    public static ClonedBeanSerializer createDummy(JavaType forType)
+    {
+        return new ClonedBeanSerializer(forType, null, NO_PROPS, null);
+    }
+
+    @Override
+    public JsonSerializer<Object> unwrappingSerializer(NameTransformer unwrapper) {
+        return new UnwrappingBeanSerializer(this, unwrapper);
+    }
+
+    @Override
+    public BeanSerializerBase withObjectIdWriter(ObjectIdWriter objectIdWriter) {
+        return new ClonedBeanSerializer(this, objectIdWriter, _propertyFilterId);
+    }
+
+    @Override
+    protected BeanSerializerBase withFilterId(Object filterId) {
+        return new ClonedBeanSerializer(this, _objectIdWriter, filterId);
+    }
+
+    @Override
+    protected BeanSerializerBase withIgnorals(String[] toIgnore) {
+        return new ClonedBeanSerializer(this, toIgnore);
+    }
+
+    /**
+     * Implementation has to check whether as-array serialization
+     * is possible reliably; if (and only if) so, will construct
+     * a {@link BeanAsArraySerializer}, otherwise will return this
+     * serializer as is.
+     */
+    @Override
+    protected BeanSerializerBase asArraySerializer()
+    {
+        /* Can not:
+         *
+         * - have Object Id (may be allowed in future)
+         * - have "any getter"
+         * - have per-property filters
+         */
+        if ((_objectIdWriter == null)
+                && (_anyGetterWriter == null)
+                && (_propertyFilterId == null)
+                ) {
+            return new BeanAsArraySerializer(this);
+        }
+        // already is one, so:
+        return this;
+    }
+
+    /*
+    /**********************************************************
+    /* JsonSerializer implementation that differs between impls
+    /**********************************************************
+     */
+
+    /**
+     * Main serialization method that will delegate actual output to
+     * configured
+     * {@link BeanPropertyWriter} instances.
+     */
+    @Override
+    public void serialize(Object bean, JsonGenerator gen, SerializerProvider provider)
+            throws IOException
+    {
+        if (_objectIdWriter != null) {
+            _serializeWithObjectId(bean, gen, provider, true);
+            return;
+        }
+        gen.writeStartObject();
+        // [databind#631]: Assign current value, to be accessible by custom serializers
+        gen.setCurrentValue(bean);
+        if (_propertyFilterId != null) {
+            serializeFieldsFiltered(bean, gen, provider);
+        } else {
+            serializeFields(bean, gen, provider);
+        }
+        gen.writeEndObject();
+    }
+
+    /*
+    /**********************************************************
+    /* Standard methods
+    /**********************************************************
+     */
+
+    @Override public String toString() {
+        return "BeanSerializer for "+handledType().getName();
+    }
+}

--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/Hibernate4Module.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/Hibernate4Module.java
@@ -3,6 +3,8 @@ package com.fasterxml.jackson.datatype.hibernate4;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ser.DefaultSerializerProvider;
 import org.hibernate.SessionFactory;
 import org.hibernate.engine.spi.Mapping;
 
@@ -137,7 +139,14 @@ public class Hibernate4Module extends Module
         if (ai != null) {
             context.appendAnnotationIntrospector(ai);
         }
-        context.addSerializers(new HibernateSerializers(_mapping, _moduleFeatures));
+        ObjectMapper objectMapper = context.getOwner();
+        DefaultSerializerProvider defaultSerializerProvider = ((DefaultSerializerProvider) objectMapper
+                .getSerializerProvider());
+        context.addSerializers(new HibernateSerializers(
+                defaultSerializerProvider.createInstance(
+                        objectMapper.getSerializationConfig(),
+                        objectMapper.getSerializerFactory()), _mapping,
+                _moduleFeatures));
         context.addBeanSerializerModifier(new HibernateSerializerModifier(_moduleFeatures, _sessionFactory));
     }
 

--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/HibernateSerializers.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/HibernateSerializers.java
@@ -1,29 +1,38 @@
 package com.fasterxml.jackson.datatype.hibernate4;
 
-import com.fasterxml.jackson.databind.BeanDescription;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializationConfig;
-import com.fasterxml.jackson.databind.ser.Serializers;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.ser.*;
+import com.fasterxml.jackson.databind.ser.std.MapSerializer;
+import com.fasterxml.jackson.databind.type.*;
 import com.fasterxml.jackson.datatype.hibernate4.Hibernate4Module.Feature;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.proxy.HibernateProxy;
 
-public class HibernateSerializers extends Serializers.Base
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class HibernateSerializers
+        extends BeanSerializerFactory implements Serializers
 {
     protected final boolean _forceLoading;
     protected final boolean _serializeIdentifiers;
     protected final Mapping _mapping;
+    private SerializerProvider _prov;
 
     public HibernateSerializers(int features) {
-        this(null, features);
+        this(null, null, features);
     }
 
-    public HibernateSerializers(Mapping mapping, int features)
+    public HibernateSerializers(SerializerProvider prov, Mapping mapping, int features)
     {
+        super(null);
         _forceLoading = Feature.FORCE_LAZY_LOADING.enabledIn(features);
         _serializeIdentifiers = Feature.SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS.enabledIn(features);
         _mapping = mapping;
+        _prov = prov;
     }
 
     @Override
@@ -32,8 +41,132 @@ public class HibernateSerializers extends Serializers.Base
     {
         Class<?> raw = type.getRawClass();
         if (HibernateProxy.class.isAssignableFrom(raw)) {
-            return new HibernateProxySerializer(_forceLoading, _serializeIdentifiers, _mapping);
+            try {
+                BeanSerializerBuilder builder = constructBeanSerializerBuilder(beanDesc);
+                // BuilderUtil.setConfig(builder, config);
+
+                // First: any detectable (auto-detect, annotations) properties
+                // to serialize?
+                List<BeanPropertyWriter> props;
+                props = findBeanProperties(_prov, beanDesc, builder);
+                if (props == null) {
+                    props = new ArrayList<BeanPropertyWriter>();
+                }
+                // [JACKSON-440] Need to allow modification bean properties to
+                // serialize:
+                if (_factoryConfig.hasSerializerModifiers()) {
+                    for (BeanSerializerModifier mod : _factoryConfig
+                            .serializerModifiers()) {
+                        props = mod.changeProperties(config, beanDesc, props);
+                    }
+                }
+
+                // Any properties to suppress?
+                props = filterBeanProperties(config, beanDesc, props);
+
+                // remove hibernate internal properties
+                Iterator<BeanPropertyWriter> iterator = props.iterator();
+                while (iterator.hasNext()) {
+                    BeanPropertyWriter beanPropertyWriter = iterator.next();
+                    if (beanPropertyWriter.getName().equals("handler")
+                            || beanPropertyWriter.getName().equals(
+                            "hibernateLazyInitializer")) {
+                        iterator.remove();
+                    }
+                }
+
+                // [JACKSON-440] Need to allow reordering of properties to
+                // serialize
+                if (_factoryConfig.hasSerializerModifiers()) {
+                    for (BeanSerializerModifier mod : _factoryConfig
+                            .serializerModifiers()) {
+                        props = mod.orderProperties(config, beanDesc, props);
+                    }
+                }
+
+				/*
+				 * And if Object Id is needed, some preparation for that as
+				 * well: better do before view handling, mostly for the custom
+				 * id case which needs access to a property
+				 */
+                builder.setObjectIdWriter(constructObjectIdHandler(_prov,
+                        beanDesc, props));
+
+                builder.setProperties(props);
+                builder.setFilterId(findFilterId(config, beanDesc));
+
+                AnnotatedMember anyGetter = beanDesc.findAnyGetter();
+                if (anyGetter != null) {
+                    if (config.canOverrideAccessModifiers()) {
+                        anyGetter.fixAccess();
+                    }
+                    JavaType type2 = anyGetter.getType(beanDesc
+                            .bindingsForBeanType());
+                    // copied from BasicSerializerFactory.buildMapSerializer():
+                    boolean staticTyping = config
+                            .isEnabled(MapperFeature.USE_STATIC_TYPING);
+                    JavaType valueType = type.getContentType();
+                    TypeSerializer typeSer = createTypeSerializer(config,
+                            valueType);
+                    // last 2 nulls; don't know key, value serializers (yet)
+                    // TODO: support '@JsonIgnoreProperties' with any setter?
+                    MapSerializer mapSer = MapSerializer.construct(/*
+																	 * ignored
+																	 * props
+																	 */null,
+                            type2, staticTyping, typeSer, null, null, /* filterId */
+                            null);
+                    // TODO: can we find full PropertyName?
+                    PropertyName name = new PropertyName(anyGetter.getName());
+                    BeanProperty.Std anyProp = new BeanProperty.Std(name,
+                            valueType, null, beanDesc.getClassAnnotations(),
+                            anyGetter, PropertyMetadata.STD_OPTIONAL);
+                    builder.setAnyGetter(new AnyGetterWriter(anyProp,
+                            anyGetter, mapSer));
+                }
+                // Next: need to gather view information, if any:
+                processViews(config, builder);
+
+                // Finally: let interested parties mess with the result bit
+                // more...
+                if (_factoryConfig.hasSerializerModifiers()) {
+                    for (BeanSerializerModifier mod : _factoryConfig
+                            .serializerModifiers()) {
+                        builder = mod.updateBuilder(config, beanDesc, builder);
+                    }
+                }
+                return new HibernateProxySerializer(type, builder,
+                        props.toArray(new BeanPropertyWriter[] {}), builder.getFilteredProperties(),
+                        _forceLoading, _serializeIdentifiers, _mapping);
+            } catch (JsonMappingException e) {
+                throw new RuntimeException(e.getMessage(), e);
+            }
         }
+        return null;
+    }
+
+    @Override
+    public JsonSerializer<?> findArraySerializer(SerializationConfig config, ArrayType type, BeanDescription beanDesc, TypeSerializer elementTypeSerializer, JsonSerializer<Object> elementValueSerializer) {
+        return null;
+    }
+
+    @Override
+    public JsonSerializer<?> findCollectionSerializer(SerializationConfig config, CollectionType type, BeanDescription beanDesc, TypeSerializer elementTypeSerializer, JsonSerializer<Object> elementValueSerializer) {
+        return null;
+    }
+
+    @Override
+    public JsonSerializer<?> findCollectionLikeSerializer(SerializationConfig config, CollectionLikeType type, BeanDescription beanDesc, TypeSerializer elementTypeSerializer, JsonSerializer<Object> elementValueSerializer) {
+        return null;
+    }
+
+    @Override
+    public JsonSerializer<?> findMapSerializer(SerializationConfig config, MapType type, BeanDescription beanDesc, JsonSerializer<Object> keySerializer, TypeSerializer elementTypeSerializer, JsonSerializer<Object> elementValueSerializer) {
+        return null;
+    }
+
+    @Override
+    public JsonSerializer<?> findMapLikeSerializer(SerializationConfig config, MapLikeType type, BeanDescription beanDesc, JsonSerializer<Object> keySerializer, TypeSerializer elementTypeSerializer, JsonSerializer<Object> elementValueSerializer) {
         return null;
     }
 }


### PR DESCRIPTION
(fix for #41)

Plagiarizes https://github.com/FasterXML/jackson-datatype-hibernate/pull/69.

Without formating issues and systematic hibernate proxy loading.
Now @JsonIgnore, @JsonIdentityInfo and @JsonFilter are used even when serializing Hibernate proxies.

Thank you @ManuelB !
