### PR TITLE
improve SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS feature

### DIFF
--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/Hibernate4Module.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/Hibernate4Module.java
@@ -31,10 +31,19 @@ public class Hibernate4Module extends Module
         USE_TRANSIENT_ANNOTATION(true),
         
 	    /**
-	     * If FORCE_LAZY_LOADING is false lazy-loaded object should be serialized as map IdentifierName=>IdentifierValue
-	     * instead of null (true); or serialized as nulls (false)
+	     * If FORCE_LAZY_LOADING is false, this feature serializes uninitialized lazy loading proxies as
+	     * <code>{"identifierName":"identifierValue"}</code> rather than <code>null</code>. 
 	     * <p>
-	     * Default value is false.
+         * Default value is false.
+	     * <p>
+	     * Note that the name of the identifier property can only be determined if 
+	     * <ul>
+	     * <li>the {@link Mapping} is provided to the Hibernate4Module, or </li>
+	     * <li>the persistence context that loaded the proxy has not yet been closed, or</li> 
+	     * <li>the id property is mapped with property access (for instance because the {@code @Id}
+	     * annotation is applied to a method rather than a field)</li>
+	     * </ul>
+	     * Otherwise, the entity name will be used instead. 
 	     */
         SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS(false),
 

--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/HibernateProxySerializer.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/HibernateProxySerializer.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.datatype.hibernate4;
 
+import java.beans.Introspector;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -228,10 +229,10 @@ public class HibernateProxySerializer
                 }
                 String name = idGetter.getName();
                 if (name.startsWith("get")) {
-                    name = Character.toLowerCase(name.charAt(3)) + name.substring(4);
+                    name = Introspector.decapitalize(name.substring(3));
                 }
                 return name;
-            } catch (Exception e) {
+            } catch (IllegalAccessException e) {
                 throw new RuntimeException(e);
             }
         }

--- a/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/LazyLoadingTest.java
+++ b/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/LazyLoadingTest.java
@@ -6,7 +6,9 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.hibernate4.Hibernate4Module.Feature;
 import com.fasterxml.jackson.datatype.hibernate4.data.Customer;
 import com.fasterxml.jackson.datatype.hibernate4.data.Payment;
 
@@ -53,5 +55,26 @@ public class LazyLoadingTest extends BaseTest
         } finally {
             emf.close();
         }
+    }
+    
+    @Test
+    public void testSerializeIdentifierFeature() throws JsonProcessingException {
+		Hibernate4Module module = new Hibernate4Module();
+		module.enable(Feature.SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS);
+		ObjectMapper objectMapper = new ObjectMapper().registerModule(module);
+
+		EntityManagerFactory emf = Persistence.createEntityManagerFactory("persistenceUnit");
+    	try {
+    		EntityManager em = emf.createEntityManager();
+    		Customer customerRef = em.getReference(Customer.class, 103);
+    		em.close();
+    		assertFalse(Hibernate.isInitialized(customerRef));
+    		
+			String json = objectMapper.writeValueAsString(customerRef);
+			assertFalse(Hibernate.isInitialized(customerRef));
+			assertEquals("{\"customerNumber\":103}", json);
+    	} finally {
+    		emf.close();
+    	}
     }
 }

--- a/hibernate5/src/main/java/com/fasterxml/jackson/datatype/hibernate5/Hibernate5Module.java
+++ b/hibernate5/src/main/java/com/fasterxml/jackson/datatype/hibernate5/Hibernate5Module.java
@@ -31,10 +31,19 @@ public class Hibernate5Module extends Module
         USE_TRANSIENT_ANNOTATION(true),
         
 	    /**
-	     * If FORCE_LAZY_LOADING is false lazy-loaded object should be serialized as map IdentifierName=>IdentifierValue
-	     * instead of null (true); or serialized as nulls (false)
+	     * If FORCE_LAZY_LOADING is false, this feature serializes uninitialized lazy loading proxies as
+	     * <code>{"identifierName":"identifierValue"}</code> rather than <code>null</code>. 
 	     * <p>
-	     * Default value is false.
+         * Default value is false.
+	     * <p>
+	     * Note that the name of the identifier property can only be determined if 
+	     * <ul>
+	     * <li>the {@link Mapping} is provided to the Hibernate5Module, or </li>
+	     * <li>the persistence context that loaded the proxy has not yet been closed, or</li> 
+	     * <li>the id property is mapped with property access (for instance because the {@code @Id}
+	     * annotation is applied to a method rather than a field)</li>
+	     * </ul>
+	     * Otherwise, the entity name will be used instead. 
 	     */
         SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS(false),
 

--- a/hibernate5/src/main/java/com/fasterxml/jackson/datatype/hibernate5/HibernateProxySerializer.java
+++ b/hibernate5/src/main/java/com/fasterxml/jackson/datatype/hibernate5/HibernateProxySerializer.java
@@ -1,6 +1,9 @@
 package com.fasterxml.jackson.datatype.hibernate5;
 
+import java.beans.Introspector;
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.HashMap;
 
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -18,6 +21,7 @@ import org.hibernate.engine.spi.Mapping;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.proxy.LazyInitializer;
+import org.hibernate.proxy.pojo.BasicLazyInitializer;
 
 /**
  * Serializer to use for values proxied using {@link org.hibernate.proxy.HibernateProxy}.
@@ -174,7 +178,7 @@ public class HibernateProxySerializer
         LazyInitializer init = proxy.getHibernateLazyInitializer();
         if (!_forceLazyLoading && init.isUninitialized()) {
             if (_serializeIdentifier) {
-                final String idName;
+                String idName;
                 if (_mapping != null) {
                     idName = _mapping.getIdentifierPropertyName(init.getEntityName());
                 } else {
@@ -182,7 +186,10 @@ public class HibernateProxySerializer
                     if (session != null) {
                         idName = session.getFactory().getIdentifierPropertyName(init.getEntityName());
                     } else {
-                        idName = init.getEntityName();
+                        idName = ProxyReader.getIdentifierPropertyName(init);
+                        if (idName == null) {
+                        	idName = init.getEntityName();
+                        }
                     }
                 }
         		final Object idValue = init.getIdentifier();
@@ -193,5 +200,46 @@ public class HibernateProxySerializer
             return null;
         }
         return init.getImplementation();
+    }
+    
+    /**
+     * Inspects a Hibernate proxy to try and determine the name of the identifier property
+     * (Hibernate proxies know the getter of the identifier property because it receives special 
+     * treatment in the invocation handler). Alas, the field storing the method reference is 
+     * private and has no getter, so we must resort to ugly reflection hacks to read its value ... 
+     */
+    protected static class ProxyReader {
+
+        // static final so the JVM can inline the lookup
+        private static final Field getIdentifierMethodField;
+
+        static {
+            try {
+                getIdentifierMethodField = BasicLazyInitializer.class.getDeclaredField("getIdentifierMethod");
+                getIdentifierMethodField.setAccessible(true);
+            } catch (Exception e) {
+            	// should never happen: the field exists in all versions of hibernate 4 and 5
+                throw new RuntimeException(e); 
+            }
+        }
+
+        /**
+         * @return the name of the identifier property, or null if the name could not be determined
+         */
+        static String getIdentifierPropertyName(LazyInitializer init) {
+            try {
+                Method idGetter = (Method) getIdentifierMethodField.get(init);
+                if (idGetter == null) {
+                	return null;
+                }
+                String name = idGetter.getName();
+                if (name.startsWith("get")) {
+                    name = Introspector.decapitalize(name.substring(3));
+                }
+                return name;
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 }


### PR DESCRIPTION
to no longer require session or mapping if ids are mapped with property access

This fixes #50 for identifier properties mapped with property rather than field access, and documents workarounds for anyone else.

Currently, this PR only updates the Hibernate4Module; I wanted to wait for your feedback before updating the Hibernate5Module. The Hibernate3Module was not be updated, because it does not support the feature.