### PR TITLE
Hibernate 5.2 support jackson-datatype-hibernate5_2 module

### DIFF
--- a/hibernate5/src/main/java/com/fasterxml/jackson/datatype/hibernate5/HibernateProxySerializer.java
+++ b/hibernate5/src/main/java/com/fasterxml/jackson/datatype/hibernate5/HibernateProxySerializer.java
@@ -182,7 +182,7 @@ public class HibernateProxySerializer
                 if (_mapping != null) {
                     idName = _mapping.getIdentifierPropertyName(init.getEntityName());
                 } else {
-                    final SessionImplementor session = init.getSession();
+                    final SessionImplementor session = (SessionImplementor) init.getSession();
                     if (session != null) {
                         idName = session.getFactory().getIdentifierPropertyName(init.getEntityName());
                     } else {

--- a/hibernate5/src/test/resources/META-INF/persistence.xml
+++ b/hibernate5/src/test/resources/META-INF/persistence.xml
@@ -5,7 +5,7 @@
 	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd">
 
     <persistence-unit name="persistenceUnit" transaction-type="RESOURCE_LOCAL">
-        <provider>org.hibernate.ejb.HibernatePersistence</provider>
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
         <class>com.fasterxml.jackson.datatype.hibernate5.data.Contrato</class>
         <class>com.fasterxml.jackson.datatype.hibernate5.data.Customer</class>
         <class>com.fasterxml.jackson.datatype.hibernate5.data.Employee</class>

--- a/hibernate5_2/pom.xml
+++ b/hibernate5_2/pom.xml
@@ -1,0 +1,135 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion> 
+  <parent>
+    <groupId>com.fasterxml.jackson.datatype</groupId>
+    <artifactId>jackson-datatype-hibernate-parent</artifactId>
+    <version>2.8.6-SNAPSHOT</version>
+  </parent>
+  <artifactId>jackson-datatype-hibernate5_2</artifactId>
+  <name>Jackson-datatype-Hibernate5_2</name>
+  <packaging>bundle</packaging>
+  <description>Add-on module for Jackson (http://jackson.codehaus.org) to support
+Hibernate (http://hibernate.org) version 5.2+ data types.
+  </description>
+  <url>https://github.com/FasterXML/jackson-datatype-hibernate</url>
+  <properties>
+    <!-- Generate PackageVersion.java into this directory. -->
+    <packageVersion.dir>com/fasterxml/jackson/datatype/hibernate5</packageVersion.dir>
+    <packageVersion.package>${project.groupId}.hibernate5</packageVersion.package>
+    <packageVersion.template.input>${project.basedir}/../hibernate5/src/main/java/${packageVersion.dir}/PackageVersion.java.in</packageVersion.template.input>
+    <!-- Hibernate with JPA 2.0 -->
+    <hibernate.version>5.2.1.Final</hibernate.version>
+    <surefire.version>2.12</surefire.version>
+    <osgi.export>${project.groupId}.hibernate5</osgi.export>
+  </properties>
+
+  <dependencies>
+    <!-- Extends Jackson; supports Hibernate datatypes, so: -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <!-- 18-Dec-2015, tatu: Since 5.0.1, we get exception for
+        missing class "javax.transaction.SystemException", without this:
+      -->
+    <dependency>
+      <groupId>javax.transaction</groupId>
+      <artifactId>jta</artifactId>
+      <version>1.1</version>
+    </dependency>
+
+    <!-- what would be the best scope to use here? -->    
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core</artifactId>
+      <version>${hibernate.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-entitymanager</artifactId>
+      <version>${hibernate.version}</version>
+      <scope>provided</scope>
+    </dependency>
+	
+     <!-- and for testing, JUnit is needed -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.8.2</version>
+      <scope>test</scope>
+    </dependency>
+    <!--  and for some contributed tests Mockito -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
+	<dependency>
+	  <groupId>org.slf4j</groupId>
+	  <artifactId>slf4j-log4j12</artifactId>
+	  <version>1.6.1</version>
+	  <scope>test</scope>
+	</dependency>
+	<dependency>
+	  <groupId>log4j</groupId>
+	  <artifactId>log4j</artifactId>
+	  <version>1.2.16</version>
+	  <scope>test</scope>
+	</dependency>
+	<dependency>
+	  <groupId>com.h2database</groupId>
+	  <artifactId>h2</artifactId>
+	  <version>1.3.155</version>
+	  <scope>test</scope>
+	</dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>${project.basedir}/../hibernate5/src/main/java</sourceDirectory>
+    <testSourceDirectory>${project.basedir}/../hibernate5/src/test/java</testSourceDirectory>
+    <resources>
+      <resource>
+        <directory>${project.basedir}/../hibernate5/src/main/resources</directory>
+      </resource>
+    </resources>
+    <testResources>
+      <testResource>
+        <directory>${project.basedir}/../hibernate5/src/test/resources</directory>
+      </testResource>
+    </testResources>
+    <plugins>
+      <plugin>
+        <!-- Inherited from oss-base. Generate PackageVersion.java.-->
+        <groupId>com.google.code.maven-replacer-plugin</groupId>
+        <artifactId>replacer</artifactId>
+        <executions>
+          <execution>
+            <id>process-packageVersion</id>
+            <phase>process-sources</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+        <configuration>
+          <excludes>
+            <exclude>com/fasterxml/jackson/datatype/hibernate5/failing/*.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -50,4 +50,15 @@
     </dependencies>
   </dependencyManagement>
 
+  <profiles>
+    <profile>
+      <id>hibernate5_2</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <modules>
+        <module>hibernate5_2</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Implement hibernate 5.2 support by creating jackson-datatype-hibernate5_2 module.

- No code duplication (uses same source dir as jackson-datatype-hibernate5 module, as long the hibernate 5.2+ keeps api compatible like 5.2.x).
- Need to be build with java8.
- jackson-datatype-hibernate5_2 is ignored if built with java7 `(<activation><jdk>1.8</jdk></activation>).`

