### PR TITLE
Ignore missing entities when lazy loading is enabled

### DIFF
--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/Hibernate4Module.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/Hibernate4Module.java
@@ -78,7 +78,14 @@ public class Hibernate4Module extends Module
          *
          * @since 2.8.2
          */
-        REPLACE_PERSISTENT_COLLECTIONS(false)
+        REPLACE_PERSISTENT_COLLECTIONS(false),
+        
+        /**
+         * Using {@link #FORCE_LAZY_LOADING} may result in
+         * `javax.persistence.EntityNotFoundException`. This flag configures Jackson to
+         * ignore the error and serialize a `null`.
+         */
+        WRITE_MISSING_ENTITIES_AS_NULL(false)
         ;
 
         final boolean _defaultState;

--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/HibernateProxySerializer.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/HibernateProxySerializer.java
@@ -6,6 +6,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 
+import javax.persistence.EntityNotFoundException;
+
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.JavaType;
@@ -43,6 +45,7 @@ public class HibernateProxySerializer
 
     protected final boolean _forceLazyLoading;
     protected final boolean _serializeIdentifier;
+    protected final boolean _nullMissingEntities;
     protected final Mapping _mapping;
 
     /**
@@ -59,21 +62,26 @@ public class HibernateProxySerializer
 
     public HibernateProxySerializer(boolean forceLazyLoading)
     {
-        this(forceLazyLoading, false, null, null);
+        this(forceLazyLoading, false, false, null, null);
     }
 
     public HibernateProxySerializer(boolean forceLazyLoading, boolean serializeIdentifier) {
-        this(forceLazyLoading, serializeIdentifier, null, null);
+        this(forceLazyLoading, serializeIdentifier, false, null, null);
     }
 
     public HibernateProxySerializer(boolean forceLazyLoading, boolean serializeIdentifier, Mapping mapping) {
-        this(forceLazyLoading, serializeIdentifier, mapping, null);
+        this(forceLazyLoading, serializeIdentifier, false, mapping, null);
     }
 
-    public HibernateProxySerializer(boolean forceLazyLoading, boolean serializeIdentifier, Mapping mapping,
+    public HibernateProxySerializer(boolean forceLazyLoading, boolean serializeIdentifier, boolean nullMissingEntities, Mapping mapping) {
+        this(forceLazyLoading, serializeIdentifier, nullMissingEntities, mapping, null);
+    }
+
+    public HibernateProxySerializer(boolean forceLazyLoading, boolean serializeIdentifier, boolean nullMissingEntities, Mapping mapping,
             BeanProperty property) {
         _forceLazyLoading = forceLazyLoading;
         _serializeIdentifier = serializeIdentifier;
+        _nullMissingEntities = nullMissingEntities;
         _mapping = mapping;
         _dynamicSerializers = PropertySerializerMap.emptyForProperties();
         _property = property;
@@ -81,7 +89,7 @@ public class HibernateProxySerializer
 
     @Override
     public JsonSerializer<?> createContextual(SerializerProvider prov, BeanProperty property) {
-        return new HibernateProxySerializer(this._forceLazyLoading, _serializeIdentifier,
+        return new HibernateProxySerializer(this._forceLazyLoading, _serializeIdentifier, _nullMissingEntities,
                 _mapping, property);
     }    
 
@@ -199,7 +207,15 @@ public class HibernateProxySerializer
             }
             return null;
         }
-        return init.getImplementation();
+        try {
+            return init.getImplementation();
+        } catch (EntityNotFoundException e) {
+            if (_nullMissingEntities) {
+                return null;
+            } else {
+                throw e;
+            }
+        }
     }
     
     /**

--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/HibernateSerializers.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/HibernateSerializers.java
@@ -13,6 +13,7 @@ public class HibernateSerializers extends Serializers.Base
 {
     protected final boolean _forceLoading;
     protected final boolean _serializeIdentifiers;
+    protected final boolean _nullMissingEntities;
     protected final Mapping _mapping;
 
     public HibernateSerializers(int features) {
@@ -23,6 +24,7 @@ public class HibernateSerializers extends Serializers.Base
     {
         _forceLoading = Feature.FORCE_LAZY_LOADING.enabledIn(features);
         _serializeIdentifiers = Feature.SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS.enabledIn(features);
+        _nullMissingEntities = Feature.WRITE_MISSING_ENTITIES_AS_NULL.enabledIn(features);
         _mapping = mapping;
     }
 
@@ -32,7 +34,7 @@ public class HibernateSerializers extends Serializers.Base
     {
         Class<?> raw = type.getRawClass();
         if (HibernateProxy.class.isAssignableFrom(raw)) {
-            return new HibernateProxySerializer(_forceLoading, _serializeIdentifiers, _mapping);
+            return new HibernateProxySerializer(_forceLoading, _serializeIdentifiers, _nullMissingEntities, _mapping);
         }
         return null;
     }

--- a/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/BaseTest.java
+++ b/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/BaseTest.java
@@ -11,13 +11,23 @@ public abstract class BaseTest extends junit.framework.TestCase
 
     protected ObjectMapper mapperWithModule(boolean forceLazyLoading)
     {
-        return new ObjectMapper().registerModule(hibernateModule(forceLazyLoading));
+        return new ObjectMapper().registerModule(hibernateModule(forceLazyLoading, false));
     }
 
-    protected Hibernate4Module hibernateModule(boolean forceLazyLoading)
+    protected ObjectMapper mapperWithModule(boolean forceLazyLoading, boolean nullMissingEntities)
+    {
+        return new ObjectMapper().registerModule(hibernateModule(forceLazyLoading, nullMissingEntities));
+    }
+
+    protected Hibernate4Module hibernateModule(boolean forceLazyLoading) {
+        return hibernateModule(forceLazyLoading, false);
+    }
+    
+    protected Hibernate4Module hibernateModule(boolean forceLazyLoading, boolean nullMissingEntities)
     {
         Hibernate4Module mod = new Hibernate4Module();
         mod.configure(Hibernate4Module.Feature.FORCE_LAZY_LOADING, forceLazyLoading);
+        mod.configure(Hibernate4Module.Feature.WRITE_MISSING_ENTITIES_AS_NULL, nullMissingEntities);
         return mod;
     }
     

--- a/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/MissingEntitiesAsNullTest.java
+++ b/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/MissingEntitiesAsNullTest.java
@@ -1,0 +1,117 @@
+package com.fasterxml.jackson.datatype.hibernate4;
+
+import java.util.Map;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+import org.hibernate.Hibernate;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.hibernate4.data.Customer;
+
+// [Issue#125]
+public class MissingEntitiesAsNullTest extends BaseTest {
+    public void testMissingProductWhenMissing() throws Exception {
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory("persistenceUnit");
+
+        try {
+            EntityManager em = emf.createEntityManager();
+
+            // false -> no forcing of lazy loading
+            ObjectMapper mapper = mapperWithModule(true);
+
+            Customer customer = em.find(Customer.class, 103);
+            assertFalse(Hibernate.isInitialized(customer.getPayments()));
+            String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(customer);
+            assertNull(customer.getMissingProductCode());
+            assertNotNull(json);
+
+            Map<?, ?> stuff = mapper.readValue(json, Map.class);
+
+            assertNull(stuff.get("missingProductCode"));
+            assertNull(stuff.get("missingProduct"));
+
+        } finally {
+            emf.close();
+        }
+    }
+
+    public void testProductWithValidForeignKey() throws Exception {
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory("persistenceUnit");
+
+        try {
+            EntityManager em = emf.createEntityManager();
+
+            // false -> no forcing of lazy loading
+            ObjectMapper mapper = mapperWithModule(true);
+
+            Customer customer = em.find(Customer.class, 500);
+            assertFalse(Hibernate.isInitialized(customer.getPayments()));
+            assertNotNull(customer.getMissingProductCode());
+            String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(customer);
+            assertNotNull(json);
+
+            Map<?, ?> stuff = mapper.readValue(json, Map.class);
+
+            assertNotNull(stuff.get("missingProductCode"));
+            assertNotNull(stuff.get("missingProduct"));
+
+        } finally {
+            emf.close();
+        }
+    }
+
+    // caused by javax.persistence.EntityNotFoundException: Unable to find
+    // com.fasterxml.jackson.datatype.hibernate4.data.Product with id X10_1678
+    public void testExceptionWithInvalidForeignKey() throws Exception {
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory("persistenceUnit");
+
+        try {
+            EntityManager em = emf.createEntityManager();
+
+            // false -> no forcing of lazy loading
+            ObjectMapper mapper = mapperWithModule(true);
+
+            Customer customer = em.find(Customer.class, 501);
+            assertFalse(Hibernate.isInitialized(customer.getPayments()));
+
+            // javax.persistence.EntityNotFoundException thrown here
+            mapper.writerWithDefaultPrettyPrinter().writeValueAsString(customer);
+            // JUnit 3.8
+            fail("Expected EntityNotFoundException exception");
+
+        } catch (JsonMappingException e) {
+            assertEquals("Unable to find com.fasterxml.jackson.datatype.hibernate4.data.Product with id X10_1678", e.getCause().getMessage());
+        } finally {
+            emf.close();
+        }
+    }
+
+    public void testWriteAsNullWithInvalidForeignKey() throws Exception {
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory("persistenceUnit");
+
+        try {
+            EntityManager em = emf.createEntityManager();
+
+            // false -> no forcing of lazy loading
+            ObjectMapper mapper = mapperWithModule(true, true);
+
+            Customer customer = em.find(Customer.class, 501);
+            assertFalse(Hibernate.isInitialized(customer.getPayments()));
+            // javax.persistence.EntityNotFoundException thrown here
+            String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(customer);
+            assertNotNull(json);
+
+            Map<?, ?> stuff = mapper.readValue(json, Map.class);
+
+            assertNotNull(stuff.get("missingProductCode"));
+            assertNull(stuff.get("missingProduct"));
+
+        } finally {
+            emf.close();
+        }
+    }
+}

--- a/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/data/Customer.java
+++ b/hibernate4/src/test/java/com/fasterxml/jackson/datatype/hibernate4/data/Customer.java
@@ -25,6 +25,8 @@ public class Customer  implements java.io.Serializable
      private String postalCode;
      private String country;
      private Double creditLimit;
+     private String missingProductCode;
+     private Product missingProduct;
      private Set<Payment> payments = new HashSet<Payment>();
      private Set<Order> orders = new HashSet<Order>();
 
@@ -194,5 +196,25 @@ public class Customer  implements java.io.Serializable
     
     public void setPayments(Set<Payment> payments) {
         this.payments = payments;
+    }
+    
+    @Column(name="missingProductCode")
+    public String getMissingProductCode() {
+        return missingProductCode;
+    }
+    
+    public void setMissingProductCode(String missingProductCode) {
+        this.missingProductCode = missingProductCode;
+    }
+
+    @ManyToOne(cascade = {}, fetch = FetchType.LAZY, optional = true)
+    @JoinColumn(name = "missingProductCode", nullable = true, insertable = false, updatable = false)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Product getMissingProduct() {
+        return missingProduct;
+    }
+    
+    public void setMissingProduct(Product missingProduct) {
+        this.missingProduct = missingProduct;
     }
 }

--- a/hibernate4/src/test/resources/classicmodels.sql
+++ b/hibernate4/src/test/resources/classicmodels.sql
@@ -40,6 +40,7 @@ CREATE TABLE  `classicmodels`.`Customer` (
   `country` varchar(50) NOT NULL,
   `salesRepEmployeeNumber` int(11) DEFAULT NULL,
   `creditLimit` double DEFAULT NULL,
+  `missingProductCode` varchar(50) NULL,
   PRIMARY KEY (`customerNumber`)
 ) DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 INSERT INTO `classicmodels`.`Customer` (`customerNumber`,`customerName`,`contactLastName`,`contactFirstName`,`phone`,`addressLine1`,`addressLine2`,`city`,`state`,`postalCode`,`country`,`salesRepEmployeeNumber`,`creditLimit`) VALUES 
@@ -165,6 +166,9 @@ INSERT INTO `classicmodels`.`Customer` (`customerNumber`,`customerName`,`contact
  (489,'Double Decker Gift Stores, Ltd','Hardy','Thomas ','(171) 555-7555','120 Hanover Sq.',NULL,'London',NULL,'WA1 1DP','UK',1501,43300),
  (495,'Diecast Collectables','Franco','Valarie','6175552555','6251 Ingle Ln.',NULL,'Boston','MA','51003','USA',1188,85100),
  (496,'Kellys Gift Shop','Snowden','Tony','+64 9 5555500','Arenales 1938 3A',NULL,'Auckland  ',NULL,'','New Zealand',1612,110000);
+INSERT INTO `classicmodels`.`Customer` (`customerNumber`,`customerName`,`contactLastName`,`contactFirstName`,`phone`,`addressLine1`,`addressLine2`,`city`,`state`,`postalCode`,`country`,`salesRepEmployeeNumber`,`creditLimit`, `missingProductCode`) VALUES 
+ (500,'Customer with valid product','Schmitt','Carine ','40.32.2555','54, rue Royale',NULL,'Nantes',NULL,'44000','France',1370,21000, 'S10_1678'),
+ (501,'Customer with invalid product','Schmitt','Carine ','40.32.2555','54, rue Royale',NULL,'Nantes',NULL,'44000','France',1370,21000, 'X10_1678'),
 
 DROP TABLE IF EXISTS `classicmodels`.`Employee`;
 CREATE TABLE  `classicmodels`.`Employee` (

--- a/hibernate5/src/main/java/com/fasterxml/jackson/datatype/hibernate5/Hibernate5Module.java
+++ b/hibernate5/src/main/java/com/fasterxml/jackson/datatype/hibernate5/Hibernate5Module.java
@@ -77,7 +77,14 @@ public class Hibernate5Module extends Module
          *
          * @since 2.8.2
          */
-        REPLACE_PERSISTENT_COLLECTIONS(false)
+        REPLACE_PERSISTENT_COLLECTIONS(false),
+        
+        /**
+         * Using {@link #FORCE_LAZY_LOADING} may result in
+         * `javax.persistence.EntityNotFoundException`. This flag configures Jackson to
+         * ignore the error and serialize a `null`.
+         */
+        WRITE_MISSING_ENTITIES_AS_NULL(false)
         ;
 
         final boolean _defaultState;

--- a/hibernate5/src/main/java/com/fasterxml/jackson/datatype/hibernate5/HibernateSerializers.java
+++ b/hibernate5/src/main/java/com/fasterxml/jackson/datatype/hibernate5/HibernateSerializers.java
@@ -12,6 +12,7 @@ public class HibernateSerializers extends Serializers.Base
 {
     protected final boolean _forceLoading;
     protected final boolean _serializeIdentifiers;
+    protected final boolean _nullMissingEntities;
     protected final Mapping _mapping;
 
     public HibernateSerializers(int features) {
@@ -22,6 +23,7 @@ public class HibernateSerializers extends Serializers.Base
     {
         _forceLoading = Hibernate5Module.Feature.FORCE_LAZY_LOADING.enabledIn(features);
         _serializeIdentifiers = Hibernate5Module.Feature.SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS.enabledIn(features);
+        _nullMissingEntities = Hibernate5Module.Feature.WRITE_MISSING_ENTITIES_AS_NULL.enabledIn(features);
         _mapping = mapping;
     }
 
@@ -31,7 +33,7 @@ public class HibernateSerializers extends Serializers.Base
     {
         Class<?> raw = type.getRawClass();
         if (HibernateProxy.class.isAssignableFrom(raw)) {
-            return new HibernateProxySerializer(_forceLoading, _serializeIdentifiers, _mapping);
+            return new HibernateProxySerializer(_forceLoading, _serializeIdentifiers, _nullMissingEntities, _mapping);
         }
         return null;
     }

--- a/hibernate5/src/test/java/com/fasterxml/jackson/datatype/hibernate5/BaseTest.java
+++ b/hibernate5/src/test/java/com/fasterxml/jackson/datatype/hibernate5/BaseTest.java
@@ -22,13 +22,24 @@ public abstract class BaseTest extends junit.framework.TestCase
 
     protected ObjectMapper mapperWithModule(boolean forceLazyLoading)
     {
-        return new ObjectMapper().registerModule(hibernateModule(forceLazyLoading));
+        return new ObjectMapper().registerModule(hibernateModule(forceLazyLoading, false));
     }
 
+    protected ObjectMapper mapperWithModule(boolean forceLazyLoading, boolean nullMissingEntities)
+    {
+        return new ObjectMapper().registerModule(hibernateModule(forceLazyLoading, nullMissingEntities));
+    }
+    
     protected Hibernate5Module hibernateModule(boolean forceLazyLoading)
+    {
+        return  hibernateModule(forceLazyLoading, false);
+    }
+
+    protected Hibernate5Module hibernateModule(boolean forceLazyLoading, boolean nullMissingEntities)
     {
         Hibernate5Module mod = new Hibernate5Module();
         mod.configure(Hibernate5Module.Feature.FORCE_LAZY_LOADING, forceLazyLoading);
+        mod.configure(Hibernate5Module.Feature.WRITE_MISSING_ENTITIES_AS_NULL, nullMissingEntities);
         return mod;
     }
     

--- a/hibernate5/src/test/java/com/fasterxml/jackson/datatype/hibernate5/MissingEntitiesAsNullTest.java
+++ b/hibernate5/src/test/java/com/fasterxml/jackson/datatype/hibernate5/MissingEntitiesAsNullTest.java
@@ -1,0 +1,117 @@
+package com.fasterxml.jackson.datatype.hibernate5;
+
+import java.util.Map;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+import org.hibernate.Hibernate;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.hibernate5.data.Customer;
+
+// [Issue#125]
+public class MissingEntitiesAsNullTest extends BaseTest {
+    public void testMissingProductWhenMissing() throws Exception {
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory("persistenceUnit");
+
+        try {
+            EntityManager em = emf.createEntityManager();
+
+            // false -> no forcing of lazy loading
+            ObjectMapper mapper = mapperWithModule(true);
+
+            Customer customer = em.find(Customer.class, 103);
+            assertFalse(Hibernate.isInitialized(customer.getPayments()));
+            String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(customer);
+            assertNull(customer.getMissingProductCode());
+            assertNotNull(json);
+
+            Map<?, ?> stuff = mapper.readValue(json, Map.class);
+
+            assertNull(stuff.get("missingProductCode"));
+            assertNull(stuff.get("missingProduct"));
+
+        } finally {
+            emf.close();
+        }
+    }
+
+    public void testProductWithValidForeignKey() throws Exception {
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory("persistenceUnit");
+
+        try {
+            EntityManager em = emf.createEntityManager();
+
+            // false -> no forcing of lazy loading
+            ObjectMapper mapper = mapperWithModule(true);
+
+            Customer customer = em.find(Customer.class, 500);
+            assertFalse(Hibernate.isInitialized(customer.getPayments()));
+            assertNotNull(customer.getMissingProductCode());
+            String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(customer);
+            assertNotNull(json);
+
+            Map<?, ?> stuff = mapper.readValue(json, Map.class);
+
+            assertNotNull(stuff.get("missingProductCode"));
+            assertNotNull(stuff.get("missingProduct"));
+
+        } finally {
+            emf.close();
+        }
+    }
+
+    // caused by javax.persistence.EntityNotFoundException: Unable to find
+    // com.fasterxml.jackson.datatype.hibernate4.data.Product with id X10_1678
+    public void testExceptionWithInvalidForeignKey() throws Exception {
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory("persistenceUnit");
+
+        try {
+            EntityManager em = emf.createEntityManager();
+
+            // false -> no forcing of lazy loading
+            ObjectMapper mapper = mapperWithModule(true);
+
+            Customer customer = em.find(Customer.class, 501);
+            assertFalse(Hibernate.isInitialized(customer.getPayments()));
+
+            // javax.persistence.EntityNotFoundException thrown here
+            mapper.writerWithDefaultPrettyPrinter().writeValueAsString(customer);
+            // JUnit 3.8
+            fail("Expected EntityNotFoundException exception");
+
+        } catch (JsonMappingException e) {
+            assertEquals("Unable to find com.fasterxml.jackson.datatype.hibernate5.data.Product with id X10_1678", e.getCause().getMessage());
+        } finally {
+            emf.close();
+        }
+    }
+
+    public void testWriteAsNullWithInvalidForeignKey() throws Exception {
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory("persistenceUnit");
+
+        try {
+            EntityManager em = emf.createEntityManager();
+
+            // false -> no forcing of lazy loading
+            ObjectMapper mapper = mapperWithModule(true, true);
+
+            Customer customer = em.find(Customer.class, 501);
+            assertFalse(Hibernate.isInitialized(customer.getPayments()));
+            // javax.persistence.EntityNotFoundException thrown here
+            String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(customer);
+            assertNotNull(json);
+
+            Map<?, ?> stuff = mapper.readValue(json, Map.class);
+
+            assertNotNull(stuff.get("missingProductCode"));
+            assertNull(stuff.get("missingProduct"));
+
+        } finally {
+            emf.close();
+        }
+    }
+}

--- a/hibernate5/src/test/java/com/fasterxml/jackson/datatype/hibernate5/data/Customer.java
+++ b/hibernate5/src/test/java/com/fasterxml/jackson/datatype/hibernate5/data/Customer.java
@@ -26,6 +26,8 @@ public class Customer implements java.io.Serializable
     private String postalCode;
     private String country;
     private Double creditLimit;
+    private String missingProductCode;
+    private Product missingProduct;
     private Set<Payment> payments = new HashSet<Payment>();
     private Set<Order> orders = new HashSet<Order>();
 
@@ -195,5 +197,25 @@ public class Customer implements java.io.Serializable
 
     public void setPayments(Set<Payment> payments) {
         this.payments = payments;
+    }
+    
+    @Column(name="missingProductCode")
+    public String getMissingProductCode() {
+        return missingProductCode;
+    }
+    
+    public void setMissingProductCode(String missingProductCode) {
+        this.missingProductCode = missingProductCode;
+    }
+
+    @ManyToOne(cascade = {}, fetch = FetchType.LAZY, optional = true)
+    @JoinColumn(name = "missingProductCode", nullable = true, insertable = false, updatable = false)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Product getMissingProduct() {
+        return missingProduct;
+    }
+    
+    public void setMissingProduct(Product missingProduct) {
+        this.missingProduct = missingProduct;
     }
 }

--- a/hibernate5/src/test/resources/classicmodels.sql
+++ b/hibernate5/src/test/resources/classicmodels.sql
@@ -40,6 +40,7 @@ CREATE TABLE  `classicmodels`.`Customer` (
   `country` varchar(50) NOT NULL,
   `salesRepEmployeeNumber` int(11) DEFAULT NULL,
   `creditLimit` double DEFAULT NULL,
+  `missingProductCode` varchar(50) NULL,
   PRIMARY KEY (`customerNumber`)
 ) DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 INSERT INTO `classicmodels`.`Customer` (`customerNumber`,`customerName`,`contactLastName`,`contactFirstName`,`phone`,`addressLine1`,`addressLine2`,`city`,`state`,`postalCode`,`country`,`salesRepEmployeeNumber`,`creditLimit`) VALUES 
@@ -165,6 +166,9 @@ INSERT INTO `classicmodels`.`Customer` (`customerNumber`,`customerName`,`contact
  (489,'Double Decker Gift Stores, Ltd','Hardy','Thomas ','(171) 555-7555','120 Hanover Sq.',NULL,'London',NULL,'WA1 1DP','UK',1501,43300),
  (495,'Diecast Collectables','Franco','Valarie','6175552555','6251 Ingle Ln.',NULL,'Boston','MA','51003','USA',1188,85100),
  (496,'Kellys Gift Shop','Snowden','Tony','+64 9 5555500','Arenales 1938 3A',NULL,'Auckland  ',NULL,'','New Zealand',1612,110000);
+INSERT INTO `classicmodels`.`Customer` (`customerNumber`,`customerName`,`contactLastName`,`contactFirstName`,`phone`,`addressLine1`,`addressLine2`,`city`,`state`,`postalCode`,`country`,`salesRepEmployeeNumber`,`creditLimit`, `missingProductCode`) VALUES 
+ (500,'Customer with valid product','Schmitt','Carine ','40.32.2555','54, rue Royale',NULL,'Nantes',NULL,'44000','France',1370,21000, 'S10_1678'),
+ (501,'Customer with invalid product','Schmitt','Carine ','40.32.2555','54, rue Royale',NULL,'Nantes',NULL,'44000','France',1370,21000, 'X10_1678'),
 
 DROP TABLE IF EXISTS `classicmodels`.`Employee`;
 CREATE TABLE  `classicmodels`.`Employee` (


### PR DESCRIPTION
This minor update gets around "Unable to find ... with id ..." of `EntityNotFoundException` when `enable(Feature.WRITE_MISSING_ENTITIES_AS_NULL)`.

Fixes #125.