### PR TITLE
Replacement component for licensed java transaction api

### DIFF
--- a/hibernate5/pom.xml
+++ b/hibernate5/pom.xml
@@ -29,7 +29,7 @@ Hibernate (http://hibernate.org) version 5.x data types.
     <dependency>
       <groupId>javax.transaction</groupId>
       <artifactId>javax.transaction-api</artifactId>
-      <version>1.2</version>
+      <version>1.1-rev-1</version>
     </dependency>
 
     <!-- what would be the best scope to use here? -->

--- a/hibernate5/pom.xml
+++ b/hibernate5/pom.xml
@@ -28,8 +28,8 @@ Hibernate (http://hibernate.org) version 5.x data types.
       -->
     <dependency>
       <groupId>javax.transaction</groupId>
-      <artifactId>javax.transaction-api</artifactId>
-      <version>1.3</version>
+      <artifactId>jta</artifactId>
+      <version>1.1</version>
     </dependency>
 
     <!-- what would be the best scope to use here? -->

--- a/hibernate5/pom.xml
+++ b/hibernate5/pom.xml
@@ -28,8 +28,8 @@ Hibernate (http://hibernate.org) version 5.x data types.
       -->
     <dependency>
       <groupId>javax.transaction</groupId>
-      <artifactId>jta</artifactId>
-      <version>1.1</version>
+      <artifactId>javax.transaction-api</artifactId>
+      <version>1.3</version>
     </dependency>
 
     <!-- what would be the best scope to use here? -->

--- a/hibernate5/pom.xml
+++ b/hibernate5/pom.xml
@@ -29,7 +29,7 @@ Hibernate (http://hibernate.org) version 5.x data types.
     <dependency>
       <groupId>javax.transaction</groupId>
       <artifactId>javax.transaction-api</artifactId>
-      <version>1.3</version>
+      <version>1.2</version>
     </dependency>
 
     <!-- what would be the best scope to use here? -->

--- a/hibernate5/pom.xml
+++ b/hibernate5/pom.xml
@@ -29,7 +29,7 @@ Hibernate (http://hibernate.org) version 5.x data types.
     <dependency>
       <groupId>javax.transaction</groupId>
       <artifactId>javax.transaction-api</artifactId>
-      <version>1.1-rev-1</version>
+      <version>1.3</version>
     </dependency>
 
     <!-- what would be the best scope to use here? -->


### PR DESCRIPTION
We need to fix the below license issue for jta, in our component.
"(Unknown license) Java Transaction API (javax.transaction:jta:1.1 - http://java.sun.com/products/jta)"

Javax.transaction-api:1.3 is the replacement component for jta with license "CDDL + GPLv2 with classpath exception".
