### PR TITLE
Added a new feature to disable wrapping of identifiers during proxy serialization

### DIFF
--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/Hibernate4Module.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/Hibernate4Module.java
@@ -92,6 +92,8 @@ public class Hibernate4Module extends com.fasterxml.jackson.databind.Module
          * Feature that may be disables to unwrap the identifier
          * of the serialized entity, returning a value instead of
          * an object.
+         *
+         * @since 2.12
          */
         WRAP_IDENTIFIER_IN_OBJECT(true);
 

--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/Hibernate4Module.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/Hibernate4Module.java
@@ -28,21 +28,21 @@ public class Hibernate4Module extends com.fasterxml.jackson.databind.Module
          * Default value is true.
          */
         USE_TRANSIENT_ANNOTATION(true),
-        
+
 	    /**
 	     * If FORCE_LAZY_LOADING is false, this feature serializes uninitialized lazy loading proxies as
-	     * <code>{"identifierName":"identifierValue"}</code> rather than <code>null</code>. 
+	     * <code>{"identifierName":"identifierValue"}</code> rather than <code>null</code>.
 	     * <p>
          * Default value is false.
 	     * <p>
-	     * Note that the name of the identifier property can only be determined if 
+	     * Note that the name of the identifier property can only be determined if
 	     * <ul>
 	     * <li>the {@link Mapping} is provided to the Hibernate4Module, or </li>
-	     * <li>the persistence context that loaded the proxy has not yet been closed, or</li> 
+	     * <li>the persistence context that loaded the proxy has not yet been closed, or</li>
 	     * <li>the id property is mapped with property access (for instance because the {@code @Id}
 	     * annotation is applied to a method rather than a field)</li>
 	     * </ul>
-	     * Otherwise, the entity name will be used instead. 
+	     * Otherwise, the entity name will be used instead.
 	     */
         SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS(false),
 
@@ -58,7 +58,7 @@ public class Hibernate4Module extends com.fasterxml.jackson.databind.Module
           * <p>
           * Default value is false, meaning that laziness is considered to be the
           * default value.
-         * 
+         *
          * @since 2.4
          */
         REQUIRE_EXPLICIT_LAZY_LOADING_MARKER(false),
@@ -78,7 +78,7 @@ public class Hibernate4Module extends com.fasterxml.jackson.databind.Module
          * @since 2.8.2
          */
         REPLACE_PERSISTENT_COLLECTIONS(false),
-        
+
         /**
          * Using {@link #FORCE_LAZY_LOADING} may result in
          * `javax.persistence.EntityNotFoundException`. This flag configures Jackson to
@@ -86,8 +86,14 @@ public class Hibernate4Module extends com.fasterxml.jackson.databind.Module
          *
          * @since 2.10
          */
-        WRITE_MISSING_ENTITIES_AS_NULL(false)
-        ;
+        WRITE_MISSING_ENTITIES_AS_NULL(false),
+
+        /**
+         * Feature that may be disables to unwrap the identifier
+         * of the serialized entity, returning a value instead of
+         * an object.
+         */
+        WRAP_IDENTIFIER_IN_OBJECT(true);
 
         final boolean _defaultState;
         final int _mask;
@@ -106,7 +112,7 @@ public class Hibernate4Module extends com.fasterxml.jackson.databind.Module
             }
             return flags;
         }
-        
+
         private Feature(boolean defaultState) {
             _defaultState = defaultState;
             _mask = (1 << ordinal());
@@ -118,7 +124,7 @@ public class Hibernate4Module extends com.fasterxml.jackson.databind.Module
     }
 
     protected final static int DEFAULT_FEATURES = Feature.collectDefaults();
-    
+
     /**
      * Bit flag composed of bits that indicate which
      * {@link Feature}s

--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/HibernateProxySerializer.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/HibernateProxySerializer.java
@@ -1,12 +1,14 @@
 package com.fasterxml.jackson.datatype.hibernate4;
 
-import org.hibernate.engine.spi.Mapping;
-import org.hibernate.engine.spi.SessionImplementor;
-import org.hibernate.proxy.HibernateProxy;
-import org.hibernate.proxy.LazyInitializer;
-import org.hibernate.proxy.pojo.BasicLazyInitializer;
+import java.beans.Introspector;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.HashMap;
 
-import com.fasterxml.jackson.core.JsonGenerator;
+import javax.persistence.EntityNotFoundException;
+
+import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -17,13 +19,11 @@ import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.ContextualSerializer;
 import com.fasterxml.jackson.databind.ser.impl.PropertySerializerMap;
 
-import java.beans.Introspector;
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.HashMap;
-
-import javax.persistence.EntityNotFoundException;
+import org.hibernate.engine.spi.Mapping;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.proxy.HibernateProxy;
+import org.hibernate.proxy.LazyInitializer;
+import org.hibernate.proxy.pojo.BasicLazyInitializer;
 
 /**
  * Serializer to use for values proxied using {@link org.hibernate.proxy.HibernateProxy}.
@@ -83,7 +83,7 @@ public class HibernateProxySerializer
     }
 
     public HibernateProxySerializer(boolean forceLazyLoading, boolean serializeIdentifier, boolean nullMissingEntities, boolean wrappedIdentifier, Mapping mapping,
-            BeanProperty property) {
+        BeanProperty property) {
         _forceLazyLoading = forceLazyLoading;
         _serializeIdentifier = serializeIdentifier;
         _nullMissingEntities = nullMissingEntities;
@@ -109,7 +109,7 @@ public class HibernateProxySerializer
     public boolean isEmpty(SerializerProvider provider, HibernateProxy value) {
         return (value == null) || (findProxied(value) == null);
     }
-    
+
     @Override
     public void serialize(HibernateProxy value, JsonGenerator jgen, SerializerProvider provider)
         throws IOException
@@ -206,7 +206,7 @@ public class HibernateProxySerializer
                     } else {
                         idName = ProxyReader.getIdentifierPropertyName(init);
                         if (idName == null) {
-                            idName = init.getEntityName();
+                        	idName = init.getEntityName();
                         }
                     }
                 }
@@ -233,7 +233,7 @@ public class HibernateProxySerializer
             }
         }
     }
-    
+
     /**
      * Inspects a Hibernate proxy to try and determine the name of the identifier property
      * (Hibernate proxies know the getter of the identifier property because it receives special 
@@ -251,7 +251,7 @@ public class HibernateProxySerializer
                 getIdentifierMethodField.setAccessible(true);
             } catch (Exception e) {
             	// should never happen: the field exists in all versions of hibernate 4 and 5
-                throw new RuntimeException(e); 
+                throw new RuntimeException(e);
             }
         }
 

--- a/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/HibernateSerializers.java
+++ b/hibernate4/src/main/java/com/fasterxml/jackson/datatype/hibernate4/HibernateSerializers.java
@@ -14,6 +14,7 @@ public class HibernateSerializers extends Serializers.Base
     protected final boolean _forceLoading;
     protected final boolean _serializeIdentifiers;
     protected final boolean _nullMissingEntities;
+    protected final boolean _wrappedIdentifier;
     protected final Mapping _mapping;
 
     public HibernateSerializers(int features) {
@@ -25,6 +26,7 @@ public class HibernateSerializers extends Serializers.Base
         _forceLoading = Feature.FORCE_LAZY_LOADING.enabledIn(features);
         _serializeIdentifiers = Feature.SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS.enabledIn(features);
         _nullMissingEntities = Feature.WRITE_MISSING_ENTITIES_AS_NULL.enabledIn(features);
+        _wrappedIdentifier = Feature.WRAP_IDENTIFIER_IN_OBJECT.enabledIn(features);
         _mapping = mapping;
     }
 
@@ -34,7 +36,7 @@ public class HibernateSerializers extends Serializers.Base
     {
         Class<?> raw = type.getRawClass();
         if (HibernateProxy.class.isAssignableFrom(raw)) {
-            return new HibernateProxySerializer(_forceLoading, _serializeIdentifiers, _nullMissingEntities, _mapping);
+            return new HibernateProxySerializer(_forceLoading, _serializeIdentifiers, _nullMissingEntities, _wrappedIdentifier, _mapping);
         }
         return null;
     }

--- a/hibernate5/src/main/java/com/fasterxml/jackson/datatype/hibernate5/Hibernate5Module.java
+++ b/hibernate5/src/main/java/com/fasterxml/jackson/datatype/hibernate5/Hibernate5Module.java
@@ -92,6 +92,8 @@ public class Hibernate5Module extends com.fasterxml.jackson.databind.Module
          * Feature that may be disables to unwrap the identifier
          * of the serialized entity, returning a value instead of
          * an object.
+         *
+         * @since 2.12
          */
         WRAP_IDENTIFIER_IN_OBJECT(true)
         ;

--- a/hibernate5/src/main/java/com/fasterxml/jackson/datatype/hibernate5/Hibernate5Module.java
+++ b/hibernate5/src/main/java/com/fasterxml/jackson/datatype/hibernate5/Hibernate5Module.java
@@ -86,7 +86,14 @@ public class Hibernate5Module extends com.fasterxml.jackson.databind.Module
          *
          * @since 2.10
          */
-        WRITE_MISSING_ENTITIES_AS_NULL(false)
+        WRITE_MISSING_ENTITIES_AS_NULL(false),
+
+        /**
+         * Feature that may be disables to unwrap the identifier
+         * of the serialized entity, returning a value instead of
+         * an object.
+         */
+        WRAP_IDENTIFIER_IN_OBJECT(true)
         ;
 
         final boolean _defaultState;

--- a/hibernate5/src/main/java/com/fasterxml/jackson/datatype/hibernate5/HibernateSerializers.java
+++ b/hibernate5/src/main/java/com/fasterxml/jackson/datatype/hibernate5/HibernateSerializers.java
@@ -13,6 +13,7 @@ public class HibernateSerializers extends Serializers.Base
     protected final boolean _forceLoading;
     protected final boolean _serializeIdentifiers;
     protected final boolean _nullMissingEntities;
+    protected final boolean _wrappedIdentifier;
     protected final Mapping _mapping;
 
     public HibernateSerializers(int features) {
@@ -24,6 +25,7 @@ public class HibernateSerializers extends Serializers.Base
         _forceLoading = Hibernate5Module.Feature.FORCE_LAZY_LOADING.enabledIn(features);
         _serializeIdentifiers = Hibernate5Module.Feature.SERIALIZE_IDENTIFIER_FOR_LAZY_NOT_LOADED_OBJECTS.enabledIn(features);
         _nullMissingEntities = Hibernate5Module.Feature.WRITE_MISSING_ENTITIES_AS_NULL.enabledIn(features);
+        _wrappedIdentifier = Hibernate5Module.Feature.WRAP_IDENTIFIER_IN_OBJECT.enabledIn(features);
         _mapping = mapping;
     }
 
@@ -33,7 +35,7 @@ public class HibernateSerializers extends Serializers.Base
     {
         Class<?> raw = type.getRawClass();
         if (HibernateProxy.class.isAssignableFrom(raw)) {
-            return new HibernateProxySerializer(_forceLoading, _serializeIdentifiers, _nullMissingEntities, _mapping);
+            return new HibernateProxySerializer(_forceLoading, _serializeIdentifiers, _nullMissingEntities, _wrappedIdentifier, _mapping);
         }
         return null;
     }


### PR DESCRIPTION

Following issue #136, this PR is intended to add a new backswards-compatible feature, that allows serialization of lazy loaded objects as identifiers in numeric values, rather than wrapped in objects. The new Feature "WRAP_IDENTIFIER_IN_OBJECT" (i.e. current behaviour) is enabled by default (to avoid double negative), and can be disabled if desired.