### PR TITLE
typo in licenses

### DIFF
--- a/hibernate4/src/main/resources/META-INF/LICENSE
+++ b/hibernate4/src/main/resources/META-INF/LICENSE
@@ -1,7 +1,7 @@
 This copy of Jackson JSON processor streaming parser/generator is licensed under the
 Apache (Software) License, version 2.0 ("the License").
 See the License for details about distribution rights, and the
-specific rights regarding derivate works.
+specific rights regarding derivative works.
 
 You may obtain a copy of the License at:
 

--- a/hibernate4/src/main/resources/META-INF/LICENSE
+++ b/hibernate4/src/main/resources/META-INF/LICENSE
@@ -1,4 +1,4 @@
-This copy of Jackson JSON processor streaming parser/generator is licensed under the
+This copy of Jackson Hibernate processor streaming parser/generator is licensed under the
 Apache (Software) License, version 2.0 ("the License").
 See the License for details about distribution rights, and the
 specific rights regarding derivative works.

--- a/hibernate5-jakarta/src/main/resources/META-INF/LICENSE
+++ b/hibernate5-jakarta/src/main/resources/META-INF/LICENSE
@@ -1,7 +1,7 @@
 This copy of Jackson JSON processor streaming parser/generator is licensed under the
 Apache (Software) License, version 2.0 ("the License").
 See the License for details about distribution rights, and the
-specific rights regarding derivate works.
+specific rights regarding derivative works.
 
 You may obtain a copy of the License at:
 

--- a/hibernate5-jakarta/src/main/resources/META-INF/LICENSE
+++ b/hibernate5-jakarta/src/main/resources/META-INF/LICENSE
@@ -1,4 +1,4 @@
-This copy of Jackson JSON processor streaming parser/generator is licensed under the
+This copy of Jackson Hibernate processor streaming parser/generator is licensed under the
 Apache (Software) License, version 2.0 ("the License").
 See the License for details about distribution rights, and the
 specific rights regarding derivative works.

--- a/hibernate5/src/main/resources/META-INF/LICENSE
+++ b/hibernate5/src/main/resources/META-INF/LICENSE
@@ -1,7 +1,7 @@
 This copy of Jackson JSON processor streaming parser/generator is licensed under the
 Apache (Software) License, version 2.0 ("the License").
 See the License for details about distribution rights, and the
-specific rights regarding derivate works.
+specific rights regarding derivative works.
 
 You may obtain a copy of the License at:
 

--- a/hibernate5/src/main/resources/META-INF/LICENSE
+++ b/hibernate5/src/main/resources/META-INF/LICENSE
@@ -1,4 +1,4 @@
-This copy of Jackson JSON processor streaming parser/generator is licensed under the
+This copy of Jackson Hibernate processor streaming parser/generator is licensed under the
 Apache (Software) License, version 2.0 ("the License").
 See the License for details about distribution rights, and the
 specific rights regarding derivative works.


### PR DESCRIPTION
I meant to create a PR for https://github.com/FasterXML/jackson-datatype-hibernate/commit/b47d9cf3d7c94a72a6aa446d9d4537a9cf1d771a but accidentally committed directly to master branch of this repo. I can revert it and do a new PR if that is required. That extra change is due to the fact the hibernate6 module is new.