### PR TITLE
Update hibernate 6 code to avoid deprecated code

### DIFF
--- a/hibernate6/src/main/java/com/fasterxml/jackson/datatype/hibernate6/Hibernate6ProxySerializer.java
+++ b/hibernate6/src/main/java/com/fasterxml/jackson/datatype/hibernate6/Hibernate6ProxySerializer.java
@@ -8,7 +8,7 @@ import java.util.HashMap;
 
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.proxy.LazyInitializer;
 import org.hibernate.proxy.pojo.BasicLazyInitializer;
@@ -249,6 +249,7 @@ public class Hibernate6ProxySerializer
         if (_mapping != null) {
             idName = _mapping.getIdentifierPropertyName(init.getEntityName());
         } else {
+            // no unit tests rely on this next call and Hibernate 7 does not support it
             idName = ProxySessionReader.getIdentifierPropertyName(init);
             if (idName == null) {
                 idName = ProxyReader.getIdentifierPropertyName(init);
@@ -301,47 +302,13 @@ public class Hibernate6ProxySerializer
         }
     }
     
-    /**
-     * Hibernate 5.2 broke abi compatibility of org.hibernate.proxy.LazyInitializer.getSession()
-     * The api contract changed
-     * from org.hibernate.proxy.LazyInitializer.getSession()Lorg.hibernate.engine.spi.SessionImplementor;
-     * to org.hibernate.proxy.LazyInitializer.getSession()Lorg.hibernate.engine.spi.SharedSessionContractImplementor
-     * 
-     * On hibernate 5.2 the interface SessionImplementor extends SharedSessionContractImplementor.
-     * And an instance of org.hibernate.internal.SessionImpl is returned from getSession().
-     */
     protected static class ProxySessionReader {
-    	
-    	/**
-    	 * The getSession method must be executed using reflection for compatibility purpose.
-    	 * For efficiency keep the method cached.
-    	 */
-        protected static final Method lazyInitializerGetSessionMethod;
-        
-        static {
-            try {
-                lazyInitializerGetSessionMethod = LazyInitializer.class.getMethod("getSession");
-            } catch (Exception e) {
-                // should never happen: the class and method exists in all versions of hibernate 5
-                throw new RuntimeException(e); 
-            }
-        }
-        
+
         static String getIdentifierPropertyName(LazyInitializer init) {
-            final Object session;
-            try{
-                session = lazyInitializerGetSessionMethod.invoke(init);
-            } catch (Exception e) {
-                // Should never happen
-                throw new RuntimeException(e);
-            }
-            if(session instanceof SessionImplementor){
-            	SessionFactoryImplementor factory = ((SessionImplementor)session).getFactory();
-            	return factory.getIdentifierPropertyName(init.getEntityName());
-            }else if (session != null) {
-                // Should never happen: session should be an instance of org.hibernate.internal.SessionImpl
-                // factory = session.getClass().getMethod("getFactory").invoke(session);
-                throw new RuntimeException("Session is not instance of SessionImplementor");
+            final SharedSessionContractImplementor session = init.getSession();
+            if (session != null) {
+                SessionFactoryImplementor factory = session.getFactory();
+                return factory.getIdentifierPropertyName(init.getEntityName());
             }
             return null;
         }

--- a/hibernate6/src/main/java/com/fasterxml/jackson/datatype/hibernate6/PersistentCollectionSerializer.java
+++ b/hibernate6/src/main/java/com/fasterxml/jackson/datatype/hibernate6/PersistentCollectionSerializer.java
@@ -307,8 +307,8 @@ public class PersistentCollectionSerializer
         session.setHibernateFlushMode(FlushMode.MANUAL);
 
         persistenceContext.addUninitializedDetachedCollection(
-                ((SessionFactoryImplementor) _sessionFactory).getMetamodel().collectionPersister(coll.getRole()),
-                coll
+            ((SessionFactoryImplementor) _sessionFactory).getMappingMetamodel().getCollectionDescriptor(coll.getRole()),
+            coll
         );
 
         return session;

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -6,6 +6,8 @@ Project: jackson-datatype-hibernate
 
 2.20.0 (not yet released)
 
+#186: Update hibernate 6 code to avoid deprecated code
+ (fixed by @pjfanning)
 - Generate SBOMs [JSTEP-14]
 
 2.19.1 (13-Jun-2025)


### PR DESCRIPTION
* learned during #185 that some APIs have been removed in Hibernate 7 and that they are deprecated in Hibernate 6
* updating Hibernate 6 code to use better supported APIs that work in Hibernate 7 too