### PR TITLE
Switch to reload4j in tests

### DIFF
--- a/hibernate4/pom.xml
+++ b/hibernate4/pom.xml
@@ -46,12 +46,12 @@ Hibernate (https://hibernate.org) version 4.x data types.
 	
     <dependency>
 	  <groupId>org.slf4j</groupId>
-	  <artifactId>slf4j-log4j12</artifactId>
+	  <artifactId>slf4j-reload4j</artifactId>
 	  <scope>test</scope>
     </dependency>
     <dependency>
-	  <groupId>log4j</groupId>
-	  <artifactId>log4j</artifactId>
+	  <groupId>ch.qos.reload4j</groupId>
+	  <artifactId>reload4j</artifactId>
 	  <scope>test</scope>
     </dependency>
     <dependency>

--- a/hibernate5-jakarta/pom.xml
+++ b/hibernate5-jakarta/pom.xml
@@ -57,12 +57,12 @@ Hibernate (https://hibernate.org) version 5.5 with Jakarta data types.
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hibernate5/pom.xml
+++ b/hibernate5/pom.xml
@@ -69,12 +69,12 @@ Hibernate (https://hibernate.org) version 5.x data types.
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hibernate6/pom.xml
+++ b/hibernate6/pom.xml
@@ -49,12 +49,12 @@ Hibernate (https://hibernate.org/) version 6.x with Jakarta data types.
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hibernate7/pom.xml
+++ b/hibernate7/pom.xml
@@ -49,12 +49,12 @@ Hibernate (https://hibernate.org/) version 7.x with Jakarta data types.
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -45,14 +45,14 @@
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-log4j12</artifactId>
-        <version>1.6.6</version>
+        <artifactId>slf4j-reload4j</artifactId>
+        <version>2.0.17</version>
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-        <version>1.2.17</version>
+        <groupId>ch.qos.reload4j</groupId>
+        <artifactId>reload4j</artifactId>
+        <version>1.2.26</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
* we use log4j 1.2.17 in test runs and this is leaked by by our pom files
* when you look at https://mvnrepository.com/artifact/tools.jackson.datatype/jackson-datatype-hibernate7/3.0.4 - it shows vulnerabilities because of log4j
* reload4j is log4j 1.x but with fixes